### PR TITLE
Collage Studio follow-ups: shadow defaults, gallery fixes, dialog rendering bug

### DIFF
--- a/collage-studio-backend/app/models.py
+++ b/collage-studio-backend/app/models.py
@@ -65,13 +65,16 @@ class BorderConfig(BaseModel):
 
 
 class InsertBorder(BaseModel):
-    enabled: bool = False
+    # Doc-level defaults are always enabled -- no on/off toggle in the
+    # frontend for those; width 0 is how you'd effectively turn one off.
+    # Per-insert overrides do still expose their own enabled toggle.
+    enabled: bool = True
     width: int = 6
     color: str = "#ffffff"
 
 
 class InsertShadow(BaseModel):
-    enabled: bool = False
+    enabled: bool = True
     offsetPx: float = 8
     # Direction in degrees: 0 = right, 90 = down, 180 = left, 270 = up.
     angleDeg: float = 135
@@ -120,5 +123,6 @@ class CollageDoc(BaseModel):
     border: BorderConfig = Field(default_factory=BorderConfig)
     jpegQuality: int = 92
     insertBorderDefault: InsertBorder = Field(default_factory=InsertBorder)
+    insertShadowDefault: InsertShadow = Field(default_factory=InsertShadow)
     tree: Node = Field(default_factory=FrameNode)
     inserts: list[Insert] = Field(default_factory=list)

--- a/collage-studio-backend/app/render_engine.py
+++ b/collage-studio-backend/app/render_engine.py
@@ -171,6 +171,10 @@ def _insert_border_spec(insert: Insert, default_border):
     return insert.border if insert.border is not None else default_border
 
 
+def _insert_shadow_spec(insert: Insert, default_shadow):
+    return insert.shadow if insert.shadow is not None else default_shadow
+
+
 def make_insert_shadow(size, corner_radius_frac, color, opacity, blur_px):
     """A blurred, colored silhouette of the insert's rounded shape, padded so
     the blur has room to spread outward without being clipped. Returned as
@@ -217,8 +221,8 @@ def paste_insert(canvas, doc: CollageDoc, insert: Insert, frame_rects, images, s
     px = int(cx - inset_size / 2)
     py = int(cy - inset_size / 2)
 
-    if insert.shadow is not None and insert.shadow.enabled:
-        shadow = insert.shadow
+    shadow = _insert_shadow_spec(insert, doc.insertShadowDefault)
+    if shadow and shadow.enabled:
         angle_rad = math.radians(shadow.angleDeg)
         offset = shadow.offsetPx * scale
         dx = math.cos(angle_rad) * offset

--- a/docs/collage-studio.md
+++ b/docs/collage-studio.md
@@ -51,10 +51,13 @@ three scopes (external frame, grid between frames, per-insert).
   larger quota. This is **device-local only** — nothing syncs between
   devices, and nothing ever leaves the browser (no backend involved in any
   of this). The gallery and whatever collages/tabs were open both survive a
-  full browser restart; a "Clear gallery" button in `LibraryPanel.tsx` wipes
-  the persisted images (with a confirm dialog — collages still referencing
-  a cleared image just show "missing image" afterward, same as before it
-  was cleared).
+  full browser restart; a "Clear gallery" button in `LibraryPanel.tsx`
+  removes only images **not referenced by any currently-open collage**
+  (computed via `collectImageKeys` across `useCollageStore().allDocs`, all
+  tabs, not just the active one) — with a confirm dialog naming the count.
+  Deliberately not a full wipe: an unrelated image sitting unused in the
+  gallery is exactly what you'd want cleared, but something a background
+  tab still needs shouldn't disappear just because you hit one button.
 - **Why a content hash, not metadata or a path:** collage layout files only
   store `imageKey`, not the image bytes (see "Export/Open" below). If you
   reopen a layout file and re-select the *same* original files, they hash to
@@ -145,7 +148,8 @@ CollageDoc
   canvas: { width, height }
   border: { external: {width,color}, grid: {width,color} }
   jpegQuality
-  insertBorderDefault: { enabled, width, color }
+  insertBorderDefault: { enabled, width, color }        # enabled is always true -- no UI toggle, width 0 = invisible
+  insertShadowDefault: { enabled, offsetPx, angleDeg, blurPx, opacity, color }  # same -- always true, opacity 0 = invisible
   tree: Node                 # root always covers the full canvas
   inserts: Insert[]
 
@@ -157,8 +161,20 @@ Insert
   seam: {frameIdA, frameIdB} | null    # starting position only; overridden once dragged (position wins)
   position: {cxPct, cyPct} | null      # set on drag; freely movable/resizable on the canvas, not just seam midpoints
   sizePct, focal, zoom, featherPx, cornerRadiusPct
-  border: {enabled, width, color} | null   # null = inherit insertBorderDefault
+  border: {enabled, width, color} | null                                      # null = inherit insertBorderDefault
+  shadow: {enabled, offsetPx, angleDeg, blurPx, opacity, color} | null        # null = inherit insertShadowDefault
 ```
+
+- **Insert defaults (border, shadow) are always "enabled"** — deliberately no
+  on/off toggle for `insertBorderDefault`/`insertShadowDefault` in
+  `InspectorPanel.tsx`; width/opacity of 0 is the practical "off." Per-insert
+  *overrides* (`insert.border`/`insert.shadow`, when non-null) still expose
+  their own enabled checkbox, since turning off just one insert's border or
+  shadow is a legitimate thing to want. New inserts start with
+  `shadow: null` (and `border: null`), so they pick up whatever the doc
+  defaults are automatically — "shadow for all inserts" is the out-of-the-box
+  behavior, with "Apply default shadow/border to all inserts" available to
+  reset any inserts that were given their own override back to inheriting.
 
 Note: an insert's `imageKey` defaults to the adjacent frame's image when created via the seam `+` button, but from then on it's independent -- reassigning the frame's image (or flipping it) does not affect the insert, and vice versa. Reassign an insert's image the same way as a frame: click or drag a library thumbnail onto it while it's selected.
 

--- a/src/collage-studio/CollageStudioApp.tsx
+++ b/src/collage-studio/CollageStudioApp.tsx
@@ -19,8 +19,16 @@ function CollageStudioApp() {
   return (
     <ImagePoolProvider>
       <CollageStoreProvider>
-        <DialogProvider>
-          <div className="collage-studio-page app-shell">
+        {/* DialogProvider must be *inside* .collage-studio-page, not wrapping
+            it -- it renders its popup as a sibling of {children}, and every
+            rule in collage-studio.css (including .dialog-overlay's
+            position:fixed styling) is scoped under .collage-studio-page. If
+            the popup isn't a descendant of that class, it gets no styling at
+            all and renders as a plain block element wherever it lands in
+            normal document flow -- which is exactly what "the confirm text
+            shows at the bottom of the page, unstyled" was. */}
+        <div className="collage-studio-page app-shell">
+          <DialogProvider>
             <Toolbar
               previewMode={previewMode}
               onTogglePreview={() => setPreviewMode((p) => !p)}
@@ -39,8 +47,8 @@ function CollageStudioApp() {
                 <InspectorPanel />
               </div>
             </div>
-          </div>
-        </DialogProvider>
+          </DialogProvider>
+        </div>
       </CollageStoreProvider>
     </ImagePoolProvider>
   )

--- a/src/collage-studio/collage-studio.css
+++ b/src/collage-studio/collage-studio.css
@@ -121,6 +121,13 @@
   width: 140px;
   font-size: 12px;
   padding: 1px 4px;
+  /* Explicit, not just relying on the general input[type='text'] rule --
+     that rule didn't apply here since the input previously had no `type`
+     attribute at all, leaving it on the browser's default white-on-white. */
+  background: #1c1c1f;
+  color: #eee;
+  border: 1px solid #45454c;
+  border-radius: 4px;
 }
 .collage-studio-page .tab-close {
   padding: 0 4px;

--- a/src/collage-studio/components/CanvasEditor.tsx
+++ b/src/collage-studio/components/CanvasEditor.tsx
@@ -187,8 +187,9 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
           ensureImageLoaded(insert.imageKey, pooled.objectUrl, forceRedraw)
           continue
         }
-        if (insert.shadow?.enabled) {
-          drawInsertShadow(ctx, rect, insert.cornerRadiusPct, insert.shadow, layout.scale)
+        const shadow = insert.shadow ?? doc.insertShadowDefault
+        if (shadow.enabled) {
+          drawInsertShadow(ctx, rect, insert.cornerRadiusPct, shadow, layout.scale)
         }
         drawFeatheredImage(ctx, img, rect, insert.focal, insert.zoom, insert.cornerRadiusPct, insert.featherPx * layout.scale)
         const border = insert.border ?? doc.insertBorderDefault

--- a/src/collage-studio/components/InspectorPanel.tsx
+++ b/src/collage-studio/components/InspectorPanel.tsx
@@ -1,5 +1,5 @@
 import { collectFrames } from '../model/geometry'
-import { DEFAULT_INSERT_SHADOW, MAX_ZOOM, type Insert } from '../model/collageTypes'
+import { MAX_ZOOM, type Insert } from '../model/collageTypes'
 import { updateFrame } from '../model/treeOps'
 import { useCollageStore } from '../state/collageStore'
 import { useImagePool } from '../state/imagePoolStore'
@@ -144,15 +144,7 @@ export function InspectorPanel() {
             onChange={(v) => editDoc((d) => ({ ...d, border: { ...d.border, grid: { ...d.border.grid, color: v } } }))}
           />
         </div>
-        <h4>Inserts (default)</h4>
-        <label className="field checkbox">
-          <input
-            type="checkbox"
-            checked={doc.insertBorderDefault.enabled}
-            onChange={(e) => editDoc((d) => ({ ...d, insertBorderDefault: { ...d.insertBorderDefault, enabled: e.target.checked } }))}
-          />
-          <span>Enabled</span>
-        </label>
+        <h4>Inserts (default border)</h4>
         <div className="field-row">
           <NumberField
             label="Width"
@@ -174,6 +166,52 @@ export function InspectorPanel() {
           }
         >
           Apply default border to all inserts
+        </button>
+
+        <h4>Inserts (default shadow)</h4>
+        <div className="field-row">
+          <NumberField
+            label="Size (offset px)"
+            min={0}
+            max={60}
+            step={1}
+            value={doc.insertShadowDefault.offsetPx}
+            onChange={(v) => editDoc((d) => ({ ...d, insertShadowDefault: { ...d.insertShadowDefault, offsetPx: v } }))}
+          />
+          <NumberField
+            label="Direction (deg)"
+            min={0}
+            max={360}
+            step={1}
+            value={doc.insertShadowDefault.angleDeg}
+            onChange={(v) => editDoc((d) => ({ ...d, insertShadowDefault: { ...d.insertShadowDefault, angleDeg: v } }))}
+          />
+        </div>
+        <div className="field-row">
+          <NumberField
+            label="Blur (px)"
+            min={0}
+            max={60}
+            step={1}
+            value={doc.insertShadowDefault.blurPx}
+            onChange={(v) => editDoc((d) => ({ ...d, insertShadowDefault: { ...d.insertShadowDefault, blurPx: v } }))}
+          />
+          <NumberField
+            label="Opacity"
+            min={0}
+            max={1}
+            step={0.05}
+            value={doc.insertShadowDefault.opacity}
+            onChange={(v) => editDoc((d) => ({ ...d, insertShadowDefault: { ...d.insertShadowDefault, opacity: v } }))}
+          />
+        </div>
+        <ColorField
+          label="Color"
+          value={doc.insertShadowDefault.color}
+          onChange={(v) => editDoc((d) => ({ ...d, insertShadowDefault: { ...d.insertShadowDefault, color: v } }))}
+        />
+        <button onClick={() => editDoc((d) => ({ ...d, inserts: d.inserts.map((i) => ({ ...i, shadow: null })) }))}>
+          Apply default shadow to all inserts
         </button>
       </section>
 
@@ -282,60 +320,56 @@ export function InspectorPanel() {
           <label className="field checkbox">
             <input
               type="checkbox"
-              checked={selectedInsert.shadow?.enabled ?? false}
+              checked={selectedInsert.shadow?.enabled ?? doc.insertShadowDefault.enabled}
               onChange={(e) =>
                 updateInsert(selectedInsert.id, {
-                  shadow: e.target.checked ? { ...(selectedInsert.shadow ?? DEFAULT_INSERT_SHADOW), enabled: true } : { ...(selectedInsert.shadow ?? DEFAULT_INSERT_SHADOW), enabled: false },
+                  shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), enabled: e.target.checked },
                 })
               }
             />
-            <span>Enabled</span>
+            <span>Override shadow (unchecked = use default)</span>
           </label>
-          {selectedInsert.shadow?.enabled && (
-            <>
-              <div className="field-row">
-                <NumberField
-                  label="Size (offset px)"
-                  min={0}
-                  max={60}
-                  step={1}
-                  value={selectedInsert.shadow.offsetPx}
-                  onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...selectedInsert.shadow!, offsetPx: v } })}
-                />
-                <NumberField
-                  label="Direction (deg)"
-                  min={0}
-                  max={360}
-                  step={1}
-                  value={selectedInsert.shadow.angleDeg}
-                  onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...selectedInsert.shadow!, angleDeg: v } })}
-                />
-              </div>
-              <div className="field-row">
-                <NumberField
-                  label="Blur (px)"
-                  min={0}
-                  max={60}
-                  step={1}
-                  value={selectedInsert.shadow.blurPx}
-                  onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...selectedInsert.shadow!, blurPx: v } })}
-                />
-                <NumberField
-                  label="Opacity"
-                  min={0}
-                  max={1}
-                  step={0.05}
-                  value={selectedInsert.shadow.opacity}
-                  onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...selectedInsert.shadow!, opacity: v } })}
-                />
-              </div>
-              <ColorField
-                label="Color"
-                value={selectedInsert.shadow.color}
-                onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...selectedInsert.shadow!, color: v } })}
-              />
-            </>
-          )}
+          <div className="field-row">
+            <NumberField
+              label="Size (offset px)"
+              min={0}
+              max={60}
+              step={1}
+              value={selectedInsert.shadow?.offsetPx ?? doc.insertShadowDefault.offsetPx}
+              onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), offsetPx: v } })}
+            />
+            <NumberField
+              label="Direction (deg)"
+              min={0}
+              max={360}
+              step={1}
+              value={selectedInsert.shadow?.angleDeg ?? doc.insertShadowDefault.angleDeg}
+              onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), angleDeg: v } })}
+            />
+          </div>
+          <div className="field-row">
+            <NumberField
+              label="Blur (px)"
+              min={0}
+              max={60}
+              step={1}
+              value={selectedInsert.shadow?.blurPx ?? doc.insertShadowDefault.blurPx}
+              onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), blurPx: v } })}
+            />
+            <NumberField
+              label="Opacity"
+              min={0}
+              max={1}
+              step={0.05}
+              value={selectedInsert.shadow?.opacity ?? doc.insertShadowDefault.opacity}
+              onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), opacity: v } })}
+            />
+          </div>
+          <ColorField
+            label="Color"
+            value={selectedInsert.shadow?.color ?? doc.insertShadowDefault.color}
+            onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), color: v } })}
+          />
 
           <button
             onClick={() => {

--- a/src/collage-studio/components/LibraryPanel.tsx
+++ b/src/collage-studio/components/LibraryPanel.tsx
@@ -1,22 +1,29 @@
 import { useRef, useState } from 'react'
+import { collectImageKeys } from '../model/geometry'
 import { setFrameImage } from '../model/treeOps'
 import { useCollageStore } from '../state/collageStore'
 import { useDialog } from '../state/dialogStore'
 import { useImagePool } from '../state/imagePoolStore'
 
 export function LibraryPanel() {
-  const { doc, editDoc, selectedFrameId, selectedInsertId } = useCollageStore()
+  const { doc, editDoc, selectedFrameId, selectedInsertId, allDocs } = useCollageStore()
   const pool = useImagePool()
   const dialog = useDialog()
   const [isDragOver, setIsDragOver] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
+  // Only removes images no *open* collage references -- anything still in
+  // use (even in a background tab) is kept, so this can't silently break a
+  // collage you haven't looked at recently.
   const handleClearGallery = async () => {
-    if (pool.images.length === 0) return
+    const usedKeys = new Set(allDocs.flatMap(collectImageKeys))
+    const unused = pool.images.filter((img) => !usedKeys.has(img.key))
+    if (unused.length === 0) return
+    const keptCount = pool.images.length - unused.length
     const ok = await dialog.confirm(
-      `Remove all ${pool.images.length} image(s) from your local gallery? This can't be undone -- any collage still referencing them will show "missing image" until you re-add them.`,
+      `Remove ${unused.length} unused image(s) from your local gallery? ${keptCount} still in use by open collages will be kept. This can't be undone.`,
     )
-    if (ok) await pool.clearAll()
+    if (ok) await pool.removeMany(unused.map((img) => img.key))
   }
 
   // Assigns to whichever is currently selected -- a frame or an insert (its
@@ -66,7 +73,9 @@ export function LibraryPanel() {
       {pool.images.length > 0 && (
         <div className="library-gallery-header">
           <span className="hint">{pool.images.length} image(s)</span>
-          <button onClick={handleClearGallery}>Clear gallery</button>
+          <button onClick={handleClearGallery} title="Removes images not used by any open collage; images still in use are kept">
+            Clear gallery
+          </button>
         </div>
       )}
 

--- a/src/collage-studio/components/LibraryPanel.tsx
+++ b/src/collage-studio/components/LibraryPanel.tsx
@@ -14,16 +14,19 @@ export function LibraryPanel() {
 
   // Only removes images no *open* collage references -- anything still in
   // use (even in a background tab) is kept, so this can't silently break a
-  // collage you haven't looked at recently.
+  // collage you haven't looked at recently. Computed at render time (not
+  // just inside the click handler) so the button can show/disable based on
+  // whether there's actually anything to remove.
+  const usedKeys = new Set(allDocs.flatMap(collectImageKeys))
+  const unusedImages = pool.images.filter((img) => !usedKeys.has(img.key))
+
   const handleClearGallery = async () => {
-    const usedKeys = new Set(allDocs.flatMap(collectImageKeys))
-    const unused = pool.images.filter((img) => !usedKeys.has(img.key))
-    if (unused.length === 0) return
-    const keptCount = pool.images.length - unused.length
+    if (unusedImages.length === 0) return
+    const keptCount = pool.images.length - unusedImages.length
     const ok = await dialog.confirm(
-      `Remove ${unused.length} unused image(s) from your local gallery? ${keptCount} still in use by open collages will be kept. This can't be undone.`,
+      `Remove ${unusedImages.length} unused image(s) from your local gallery? ${keptCount} still in use by open collages will be kept. This can't be undone.`,
     )
-    if (ok) await pool.removeMany(unused.map((img) => img.key))
+    if (ok) await pool.removeMany(unusedImages.map((img) => img.key))
   }
 
   // Assigns to whichever is currently selected -- a frame or an insert (its
@@ -73,8 +76,16 @@ export function LibraryPanel() {
       {pool.images.length > 0 && (
         <div className="library-gallery-header">
           <span className="hint">{pool.images.length} image(s)</span>
-          <button onClick={handleClearGallery} title="Removes images not used by any open collage; images still in use are kept">
-            Clear gallery
+          <button
+            onClick={handleClearGallery}
+            disabled={unusedImages.length === 0}
+            title={
+              unusedImages.length === 0
+                ? 'Every image here is used by an open collage -- nothing to remove'
+                : `Removes ${unusedImages.length} image(s) not used by any open collage; images still in use are kept`
+            }
+          >
+            Clear gallery{unusedImages.length > 0 ? ` (${unusedImages.length})` : ''}
           </button>
         </div>
       )}

--- a/src/collage-studio/components/Toolbar.tsx
+++ b/src/collage-studio/components/Toolbar.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react'
 import { api } from '../api/client'
 import { createBlankCollageDoc, type CollageDoc } from '../model/collageTypes'
-import { collectFrames } from '../model/geometry'
+import { collectImageKeys } from '../model/geometry'
 import { useCollageStore } from '../state/collageStore'
 import { useDialog } from '../state/dialogStore'
 import { useImagePool } from '../state/imagePoolStore'
@@ -34,22 +34,8 @@ function downloadBlob(blob: Blob, filename: string) {
   URL.revokeObjectURL(url)
 }
 
-function collectImageKeys(doc: CollageDoc): string[] {
-  const frames = collectFrames(doc.tree)
-  const keys = new Set<string>()
-  for (const frame of Object.values(frames)) {
-    if (frame.image) keys.add(frame.image.imageKey)
-  }
-  // Inserts have their own, independent image assignment (see collageTypes.ts) --
-  // not necessarily used by any frame, so must be collected separately.
-  for (const insert of doc.inserts) {
-    if (insert.imageKey) keys.add(insert.imageKey)
-  }
-  return Array.from(keys)
-}
-
 export function Toolbar({ previewMode, onTogglePreview, onToggleLibrary, onToggleInspector }: ToolbarProps) {
-  const { doc, dirty, tabs, activeId, newDoc, openDoc, closeDoc, setActive, renameDoc, undo, redo, canUndo, canRedo, markSaved } = useCollageStore()
+  const { doc, tabs, activeId, newDoc, openDoc, closeDoc, setActive, renameDoc, undo, redo, canUndo, canRedo, markSaved } = useCollageStore()
   const dialog = useDialog()
   const pool = useImagePool()
   const [status, setStatus] = useState<string | null>(null)
@@ -174,7 +160,7 @@ export function Toolbar({ previewMode, onTogglePreview, onToggleLibrary, onToggl
           }}
         />
         <button disabled={!doc} onClick={handleExportLayout}>
-          Export{dirty ? ' *' : ''}
+          Export
         </button>
         <span className="toolbar-sep" />
         <button disabled={!canUndo} onClick={undo}>
@@ -202,6 +188,7 @@ export function Toolbar({ previewMode, onTogglePreview, onToggleLibrary, onToggl
             <div key={tab.id} className={`tab${tab.id === activeId ? ' active' : ''}`} onClick={() => setActive(tab.id)}>
               {renamingTabId === tab.id ? (
                 <input
+                  type="text"
                   className="tab-rename-input"
                   value={renameValue}
                   autoFocus

--- a/src/collage-studio/model/collageTypes.ts
+++ b/src/collage-studio/model/collageTypes.ts
@@ -102,6 +102,7 @@ export interface CollageDoc {
   border: BorderConfig
   jpegQuality: number
   insertBorderDefault: InsertBorder
+  insertShadowDefault: InsertShadow
   tree: Node
   inserts: Insert[]
 }
@@ -141,7 +142,10 @@ export function createBlankCollageDoc(name = 'Untitled collage'): CollageDoc {
       grid: { width: 8, color: '#000000' },
     },
     jpegQuality: 92,
-    insertBorderDefault: { enabled: false, width: 6, color: '#ffffff' },
+    // Insert defaults are always "enabled" -- no on/off toggle in the UI for
+    // these, width/opacity of 0 is how you'd effectively turn one off.
+    insertBorderDefault: { enabled: true, width: 6, color: '#ffffff' },
+    insertShadowDefault: { ...DEFAULT_INSERT_SHADOW },
     tree: makeFrame(),
     inserts: [],
   }

--- a/src/collage-studio/model/collageTypes.ts
+++ b/src/collage-studio/model/collageTypes.ts
@@ -118,6 +118,25 @@ export const DEFAULT_INSERT_SHADOW: InsertShadow = {
   color: '#000000',
 }
 
+export const DEFAULT_INSERT_BORDER: InsertBorder = {
+  enabled: true,
+  width: 6,
+  color: '#ffffff',
+}
+
+/** Backfills fields added after this doc might have been created/persisted
+ * (IndexedDB-hydrated docs, or an older exported .collage.json) so the rest
+ * of the app can assume every CollageDoc is complete. Without this, a doc
+ * missing e.g. insertShadowDefault crashes on the first `.enabled` read --
+ * and with no error boundary, that's a blank white screen, not a nice error. */
+export function normalizeDoc(doc: CollageDoc): CollageDoc {
+  return {
+    ...doc,
+    insertBorderDefault: doc.insertBorderDefault ?? { ...DEFAULT_INSERT_BORDER },
+    insertShadowDefault: doc.insertShadowDefault ?? { ...DEFAULT_INSERT_SHADOW },
+  }
+}
+
 let idCounter = 0
 export function newId(): string {
   idCounter += 1

--- a/src/collage-studio/model/geometry.ts
+++ b/src/collage-studio/model/geometry.ts
@@ -3,7 +3,7 @@
 // constants -- so the live canvas preview never diverges from the Pillow
 // export.
 
-import { MAX_ZOOM, type FocalPoint, type FrameNode, type Node } from './collageTypes'
+import { MAX_ZOOM, type CollageDoc, type FocalPoint, type FrameNode, type Node } from './collageTypes'
 
 export type Rect = { x: number; y: number; w: number; h: number }
 
@@ -75,6 +75,20 @@ export function collectFrames(node: Node, out: Record<string, FrameNode> = {}): 
     collectFrames(node.second, out)
   }
   return out
+}
+
+/** Every imageKey a doc references, across both frames and inserts (inserts
+ * have their own independent image assignment -- see collageTypes.ts). */
+export function collectImageKeys(doc: CollageDoc): string[] {
+  const frames = collectFrames(doc.tree)
+  const keys = new Set<string>()
+  for (const frame of Object.values(frames)) {
+    if (frame.image) keys.add(frame.image.imageKey)
+  }
+  for (const insert of doc.inserts) {
+    if (insert.imageKey) keys.add(insert.imageKey)
+  }
+  return Array.from(keys)
 }
 
 /** Returns null if the two rects aren't geometrically adjacent (within gutter tolerance). */

--- a/src/collage-studio/state/collageStore.tsx
+++ b/src/collage-studio/state/collageStore.tsx
@@ -173,6 +173,9 @@ interface StoreApi {
   closeDoc: (id: string) => void
   setActive: (id: string) => void
   renameDoc: (id: string, name: string) => void
+  /** Every open collage's doc, across all tabs (not just the active one) --
+   * e.g. for "which images does any open collage still reference." */
+  allDocs: CollageDoc[]
 }
 
 const CollageStoreContext = createContext<StoreApi | null>(null)
@@ -257,6 +260,8 @@ export function CollageStoreProvider({ children }: { children: ReactNode }) {
     [state.order, state.entries],
   )
 
+  const allDocs = useMemo<CollageDoc[]>(() => state.order.map((id) => state.entries[id].doc), [state.order, state.entries])
+
   const value = useMemo<StoreApi>(
     () => ({
       doc: activeEntry?.doc ?? null,
@@ -278,8 +283,9 @@ export function CollageStoreProvider({ children }: { children: ReactNode }) {
       closeDoc,
       setActive,
       renameDoc,
+      allDocs,
     }),
-    [activeEntry, editDoc, undo, redo, selectFrame, selectInsert, markSaved, tabs, state.activeId, newDoc, openDoc, closeDoc, setActive, renameDoc],
+    [activeEntry, editDoc, undo, redo, selectFrame, selectInsert, markSaved, tabs, state.activeId, newDoc, openDoc, closeDoc, setActive, renameDoc, allDocs],
   )
 
   return <CollageStoreContext.Provider value={value}>{children}</CollageStoreContext.Provider>

--- a/src/collage-studio/state/collageStore.tsx
+++ b/src/collage-studio/state/collageStore.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useReducer, useState, type ReactNode } from 'react'
-import type { CollageDoc } from '../model/collageTypes'
+import { normalizeDoc, type CollageDoc } from '../model/collageTypes'
 import { loadSession, saveSession } from './idb'
 
 const HISTORY_LIMIT = 50
@@ -48,13 +48,17 @@ function reducer(state: State, action: Action): State {
         order: [...state.order, action.doc.id],
         activeId: action.doc.id,
       }
-    case 'OPEN_DOC':
+    case 'OPEN_DOC': {
       // Freshly loaded from a file on disk -- matches what's on disk, so it's clean.
+      // normalizeDoc backfills any fields added after this file might have been
+      // exported (e.g. an older .collage.json missing insertShadowDefault).
+      const doc = normalizeDoc(action.doc)
       return {
-        entries: { ...state.entries, [action.doc.id]: newEntry(action.doc, false) },
-        order: [...state.order, action.doc.id],
-        activeId: action.doc.id,
+        entries: { ...state.entries, [doc.id]: newEntry(doc, false) },
+        order: [...state.order, doc.id],
+        activeId: doc.id,
       }
+    }
     case 'CLOSE_DOC': {
       if (!state.entries[action.id]) return state
       const { [action.id]: _removed, ...entries } = state.entries
@@ -194,7 +198,7 @@ export function CollageStoreProvider({ children }: { children: ReactNode }) {
         const entries: Record<string, DocEntry> = {}
         for (const id of session.order) {
           const stored = session.docs[id]
-          if (stored) entries[id] = newEntry(stored.doc as CollageDoc, stored.dirty)
+          if (stored) entries[id] = newEntry(normalizeDoc(stored.doc as CollageDoc), stored.dirty)
         }
         dispatch({ type: 'HYDRATE', order: session.order, activeId: session.activeId, entries })
       })

--- a/src/collage-studio/state/idb.ts
+++ b/src/collage-studio/state/idb.ts
@@ -31,6 +31,10 @@ export interface StoredImage {
   key: string
   name: string
   blob: Blob
+  // IndexedDB's getAll() returns records ordered by the primary key (the
+  // content hash, i.e. effectively random) -- this is what lets the gallery
+  // sort by when each image was actually added instead.
+  addedAt: number
 }
 
 export async function loadAllImages(): Promise<StoredImage[]> {

--- a/src/collage-studio/state/idb.ts
+++ b/src/collage-studio/state/idb.ts
@@ -63,16 +63,6 @@ export async function deleteImage(key: string): Promise<void> {
   })
 }
 
-export async function clearImages(): Promise<void> {
-  const db = await openDb()
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(IMAGES_STORE, 'readwrite')
-    tx.objectStore(IMAGES_STORE).clear()
-    tx.oncomplete = () => resolve()
-    tx.onerror = () => reject(tx.error)
-  })
-}
-
 export interface StoredSession {
   id: 'main'
   order: string[]

--- a/src/collage-studio/state/imagePoolStore.tsx
+++ b/src/collage-studio/state/imagePoolStore.tsx
@@ -11,6 +11,7 @@ export interface PooledImage {
   file: File
   objectUrl: string
   name: string
+  addedAt: number
 }
 
 interface ImagePoolApi {
@@ -69,7 +70,7 @@ export function ImagePoolProvider({ children }: { children: ReactNode }) {
           for (const img of stored) {
             if (next.has(img.key)) continue
             const file = new File([img.blob], img.name, { type: img.blob.type })
-            next.set(img.key, { key: img.key, file, objectUrl: URL.createObjectURL(img.blob), name: img.name })
+            next.set(img.key, { key: img.key, file, objectUrl: URL.createObjectURL(img.blob), name: img.name, addedAt: img.addedAt ?? 0 })
           }
           return next
         })
@@ -91,21 +92,22 @@ export function ImagePoolProvider({ children }: { children: ReactNode }) {
     const fingerprints = await Promise.all(imageFiles.map(fingerprint))
 
     const keys: string[] = []
-    const newlyAdded: { key: string; file: File }[] = []
+    const newlyAdded: { key: string; file: File; addedAt: number }[] = []
     setPool((prev) => {
       const next = new Map(prev)
       imageFiles.forEach((file, i) => {
         const key = fingerprints[i]
         keys.push(key)
         if (next.has(key)) return
-        next.set(key, { key, file, objectUrl: URL.createObjectURL(file), name: file.name })
-        newlyAdded.push({ key, file })
+        const addedAt = Date.now()
+        next.set(key, { key, file, objectUrl: URL.createObjectURL(file), name: file.name, addedAt })
+        newlyAdded.push({ key, file, addedAt })
       })
       return next
     })
     // Persist new entries only -- fire-and-forget, the in-memory pool is the source of truth for this tab.
-    for (const { key, file } of newlyAdded) {
-      saveImage({ key, name: file.name, blob: file }).catch((e) => console.error('Failed to persist image:', e))
+    for (const { key, file, addedAt } of newlyAdded) {
+      saveImage({ key, name: file.name, blob: file, addedAt }).catch((e) => console.error('Failed to persist image:', e))
     }
     return keys
   }, [])
@@ -142,7 +144,7 @@ export function ImagePoolProvider({ children }: { children: ReactNode }) {
   const get = useCallback((key: string) => pool.get(key), [pool])
 
   const value = useMemo<ImagePoolApi>(
-    () => ({ images: Array.from(pool.values()), get, add, remove, removeMany }),
+    () => ({ images: Array.from(pool.values()).sort((a, b) => b.addedAt - a.addedAt), get, add, remove, removeMany }),
     [pool, get, add, remove, removeMany],
   )
 

--- a/src/collage-studio/state/imagePoolStore.tsx
+++ b/src/collage-studio/state/imagePoolStore.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { clearImages, deleteImage, loadAllImages, saveImage } from './idb'
+import { deleteImage, loadAllImages, saveImage } from './idb'
 
 // Image pool, persisted locally (IndexedDB) so the gallery survives a
 // browser restart -- but never leaves this device and never touches a
@@ -19,8 +19,8 @@ interface ImagePoolApi {
   /** Adds files to the pool, deduping by content fingerprint; returns the resulting keys (added or already-present). */
   add: (files: FileList | File[]) => Promise<string[]>
   remove: (key: string) => void
-  /** Wipes the entire persistent gallery. Any collage still referencing a removed image will show "missing image" until re-added. */
-  clearAll: () => Promise<void>
+  /** Removes several images at once (e.g. "Clear gallery" removing everything unused). */
+  removeMany: (keys: string[]) => Promise<void>
 }
 
 const ImagePoolContext = createContext<ImagePoolApi | null>(null)
@@ -122,17 +122,28 @@ export function ImagePoolProvider({ children }: { children: ReactNode }) {
     deleteImage(key).catch((e) => console.error('Failed to delete persisted image:', e))
   }, [])
 
-  const clearAll = useCallback(async () => {
-    for (const img of poolRef.current.values()) URL.revokeObjectURL(img.objectUrl)
-    setPool(new Map())
-    await clearImages()
+  const removeMany = useCallback(async (keys: string[]) => {
+    if (keys.length === 0) return
+    const keySet = new Set(keys)
+    setPool((prev) => {
+      const next = new Map(prev)
+      for (const key of keySet) {
+        const entry = next.get(key)
+        if (entry) {
+          URL.revokeObjectURL(entry.objectUrl)
+          next.delete(key)
+        }
+      }
+      return next
+    })
+    await Promise.all(keys.map((key) => deleteImage(key).catch((e) => console.error('Failed to delete persisted image:', e))))
   }, [])
 
   const get = useCallback((key: string) => pool.get(key), [pool])
 
   const value = useMemo<ImagePoolApi>(
-    () => ({ images: Array.from(pool.values()), get, add, remove, clearAll }),
-    [pool, get, add, remove, clearAll],
+    () => ({ images: Array.from(pool.values()), get, add, remove, removeMany }),
+    [pool, get, add, remove, removeMany],
   )
 
   return <ImagePoolContext.Provider value={value}>{children}</ImagePoolContext.Provider>


### PR DESCRIPTION
## Summary

Follow-up fixes/improvements to Collage Studio after the initial merge (#69):

- **Doc-wide insert shadow default**: `insertShadowDefault` mirrors the existing `insertBorderDefault` pattern (an "Apply default shadow to all inserts" button; any insert with `shadow: null` inherits it). New inserts start with `shadow: null`, so every insert gets a shadow out of the box instead of needing individual setup. Doc-level insert defaults (border and shadow) drop their "Enabled" checkbox entirely -- always on, width/opacity of 0 is the practical off switch. Per-insert overrides keep their own toggle.
- **Clear gallery** now only removes images not referenced by *any* open collage (checked across every tab, not just the active one) instead of wiping everything, and shows a live "(N)" unused count on the button.
- **Fixed a white-screen crash**: docs persisted to IndexedDB (or exported) before `insertShadowDefault` existed would crash the app on load reading `.enabled` off `undefined`, with no error boundary to catch it. Added `normalizeDoc()` to backfill missing fields at both entry points (session hydration, file-open).
- **Fixed dialogs rendering unstyled**: `DialogProvider` was wrapping `.collage-studio-page` instead of sitting inside it, so its popup (confirm/prompt) rendered as a sibling outside the div all of `collage-studio.css` is scoped under -- meaning zero styling, landing as a plain block at the bottom of the page. Looked exactly like "nothing happens" when clicking Clear gallery (or renaming/closing a tab), but the logic underneath was working the whole time.
- **Sort gallery by upload time**: IndexedDB's `getAll()` returns rows by primary key (content hash, effectively random), not insertion order. Added a real `addedAt` timestamp, stamped on upload and persisted, sorted newest-first (legacy pre-existing images default to timestamp 0 since there's no way to recover their real add time).
- Fixed the tab-rename input rendering white-on-white (missing `type="text"`, so the dark-theme input styling never matched it).
- Export button no longer shows a "*" for unsaved changes -- the tab itself already shows that.

## Test plan

- [x] `pnpm build` and `tsc --noEmit` clean at every commit
- [x] Backend import + live `/api/export` smoke tests, including pixel-level verification that the doc-level shadow default renders correctly when an insert's own shadow is `null`
- [ ] Manual browser pass to confirm the dialog-overlay fix actually resolves the reported issue (should now render as a centered modal, not unstyled text at the page bottom)
- [ ] Confirm Clear gallery now works end-to-end once the dialog is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)