### PR TITLE
Collage Studio: design refresh + insert/mobile/UX overhaul

### DIFF
--- a/collage-studio-backend/app/models.py
+++ b/collage-studio-backend/app/models.py
@@ -11,7 +11,7 @@ from typing import Annotated, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
-MAX_ZOOM = 1 / 0.3  # crop window never shrinks below ~30% of the base cover-crop box
+MAX_ZOOM = 1 / 0.02  # crop window never shrinks below ~2% of the base cover-crop box -- see render_engine.py
 
 
 def _id() -> str:

--- a/collage-studio-backend/app/models.py
+++ b/collage-studio-backend/app/models.py
@@ -65,13 +65,16 @@ class BorderConfig(BaseModel):
 
 
 class InsertBorder(BaseModel):
-    enabled: bool = False
+    # Doc-level defaults are always enabled -- no on/off toggle in the
+    # frontend for those; width 0 is how you'd effectively turn one off.
+    # Per-insert overrides do still expose their own enabled toggle.
+    enabled: bool = True
     width: int = 6
     color: str = "#ffffff"
 
 
 class InsertShadow(BaseModel):
-    enabled: bool = False
+    enabled: bool = True
     offsetPx: float = 8
     # Direction in degrees: 0 = right, 90 = down, 180 = left, 270 = up.
     angleDeg: float = 135
@@ -120,5 +123,6 @@ class CollageDoc(BaseModel):
     border: BorderConfig = Field(default_factory=BorderConfig)
     jpegQuality: int = 92
     insertBorderDefault: InsertBorder = Field(default_factory=InsertBorder)
+    insertShadowDefault: InsertShadow = Field(default_factory=InsertShadow)
     tree: Node = Field(default_factory=FrameNode)
     inserts: list[Insert] = Field(default_factory=list)

--- a/collage-studio-backend/app/render_engine.py
+++ b/collage-studio-backend/app/render_engine.py
@@ -171,6 +171,10 @@ def _insert_border_spec(insert: Insert, default_border):
     return insert.border if insert.border is not None else default_border
 
 
+def _insert_shadow_spec(insert: Insert, default_shadow):
+    return insert.shadow if insert.shadow is not None else default_shadow
+
+
 def make_insert_shadow(size, corner_radius_frac, color, opacity, blur_px):
     """A blurred, colored silhouette of the insert's rounded shape, padded so
     the blur has room to spread outward without being clipped. Returned as
@@ -217,8 +221,8 @@ def paste_insert(canvas, doc: CollageDoc, insert: Insert, frame_rects, images, s
     px = int(cx - inset_size / 2)
     py = int(cy - inset_size / 2)
 
-    if insert.shadow is not None and insert.shadow.enabled:
-        shadow = insert.shadow
+    shadow = _insert_shadow_spec(insert, doc.insertShadowDefault)
+    if shadow and shadow.enabled:
         angle_rad = math.radians(shadow.angleDeg)
         offset = shadow.offsetPx * scale
         dx = math.cos(angle_rad) * offset

--- a/collage-studio-backend/app/render_engine.py
+++ b/collage-studio-backend/app/render_engine.py
@@ -16,7 +16,7 @@ from PIL import Image, ImageDraw, ImageFilter, ImageOps
 
 from .models import CollageDoc, FrameNode, Insert, SplitNode
 
-MAX_ZOOM = 1 / 0.3  # crop window never shrinks below ~30% of the base cover-crop box
+MAX_ZOOM = 1 / 0.02  # crop window never shrinks below ~2% of the base cover-crop box (kept high/effectively "unlimited" for editing; mirrored in frontend model/collageTypes.ts)
 
 
 # --------------------------------------------------------------------------- image loading
@@ -48,8 +48,9 @@ class ImageStore:
 def compute_crop_box(src_w, src_h, target_w, target_h, focal_xy=(0.5, 0.5), zoom=1.0):
     """Cover-crop box in source pixel coords. zoom==1.0 is a plain focal-centred
     cover crop (only crops what's needed to match the target aspect ratio).
-    zoom>1 crops in further, clamped so the box never shrinks below ~30% of the
-    base box (i.e. up to ~3.33x tighter crop)."""
+    zoom>1 crops in further, clamped so the box never shrinks below ~2% of the
+    base box (i.e. up to ~50x tighter crop -- effectively unlimited for
+    editing purposes, just not literally infinite)."""
     fx, fy = focal_xy
     target_ratio = target_w / target_h
     src_ratio = src_w / src_h

--- a/docs/collage-studio.md
+++ b/docs/collage-studio.md
@@ -51,10 +51,13 @@ three scopes (external frame, grid between frames, per-insert).
   larger quota. This is **device-local only** — nothing syncs between
   devices, and nothing ever leaves the browser (no backend involved in any
   of this). The gallery and whatever collages/tabs were open both survive a
-  full browser restart; a "Clear gallery" button in `LibraryPanel.tsx` wipes
-  the persisted images (with a confirm dialog — collages still referencing
-  a cleared image just show "missing image" afterward, same as before it
-  was cleared).
+  full browser restart; a "Clear gallery" button in `LibraryPanel.tsx`
+  removes only images **not referenced by any currently-open collage**
+  (computed via `collectImageKeys` across `useCollageStore().allDocs`, all
+  tabs, not just the active one) — with a confirm dialog naming the count.
+  Deliberately not a full wipe: an unrelated image sitting unused in the
+  gallery is exactly what you'd want cleared, but something a background
+  tab still needs shouldn't disappear just because you hit one button.
 - **Why a content hash, not metadata or a path:** collage layout files only
   store `imageKey`, not the image bytes (see "Export/Open" below). If you
   reopen a layout file and re-select the *same* original files, they hash to
@@ -145,7 +148,8 @@ CollageDoc
   canvas: { width, height }
   border: { external: {width,color}, grid: {width,color} }
   jpegQuality
-  insertBorderDefault: { enabled, width, color }
+  insertBorderDefault: { enabled, width, color }        # enabled is always true -- no UI toggle, width 0 = invisible
+  insertShadowDefault: { enabled, offsetPx, angleDeg, blurPx, opacity, color }  # same -- always true, opacity 0 = invisible
   tree: Node                 # root always covers the full canvas
   inserts: Insert[]
 
@@ -157,8 +161,20 @@ Insert
   seam: {frameIdA, frameIdB} | null    # starting position only; overridden once dragged (position wins)
   position: {cxPct, cyPct} | null      # set on drag; freely movable/resizable on the canvas, not just seam midpoints
   sizePct, focal, zoom, featherPx, cornerRadiusPct
-  border: {enabled, width, color} | null   # null = inherit insertBorderDefault
+  border: {enabled, width, color} | null                                      # null = inherit insertBorderDefault
+  shadow: {enabled, offsetPx, angleDeg, blurPx, opacity, color} | null        # null = inherit insertShadowDefault
 ```
+
+- **Insert defaults (border, shadow) are always "enabled"** — deliberately no
+  on/off toggle for `insertBorderDefault`/`insertShadowDefault` in
+  `InspectorPanel.tsx`; width/opacity of 0 is the practical "off." Per-insert
+  *overrides* (`insert.border`/`insert.shadow`, when non-null) still expose
+  their own enabled checkbox, since turning off just one insert's border or
+  shadow is a legitimate thing to want. New inserts start with
+  `shadow: null` (and `border: null`), so they pick up whatever the doc
+  defaults are automatically — "shadow for all inserts" is the out-of-the-box
+  behavior, with "Apply default shadow/border to all inserts" available to
+  reset any inserts that were given their own override back to inheriting.
 
 Note: an insert's `imageKey` defaults to the adjacent frame's image when created via the seam `+` button, but from then on it's independent -- reassigning the frame's image (or flipping it) does not affect the insert, and vice versa. Reassign an insert's image the same way as a frame: click or drag a library thumbnail onto it while it's selected.
 

--- a/src/collage-studio/CollageStudioApp.tsx
+++ b/src/collage-studio/CollageStudioApp.tsx
@@ -19,8 +19,16 @@ function CollageStudioApp() {
   return (
     <ImagePoolProvider>
       <CollageStoreProvider>
-        <DialogProvider>
-          <div className="collage-studio-page app-shell">
+        {/* DialogProvider must be *inside* .collage-studio-page, not wrapping
+            it -- it renders its popup as a sibling of {children}, and every
+            rule in collage-studio.css (including .dialog-overlay's
+            position:fixed styling) is scoped under .collage-studio-page. If
+            the popup isn't a descendant of that class, it gets no styling at
+            all and renders as a plain block element wherever it lands in
+            normal document flow -- which is exactly what "the confirm text
+            shows at the bottom of the page, unstyled" was. */}
+        <div className="collage-studio-page app-shell">
+          <DialogProvider>
             <Toolbar
               previewMode={previewMode}
               onTogglePreview={() => setPreviewMode((p) => !p)}
@@ -39,8 +47,8 @@ function CollageStudioApp() {
                 <InspectorPanel />
               </div>
             </div>
-          </div>
-        </DialogProvider>
+          </DialogProvider>
+        </div>
       </CollageStoreProvider>
     </ImagePoolProvider>
   )

--- a/src/collage-studio/CollageStudioApp.tsx
+++ b/src/collage-studio/CollageStudioApp.tsx
@@ -62,7 +62,9 @@ function CollageStudioApp() {
             <Toolbar
               previewMode={previewMode}
               onTogglePreview={() => setPreviewMode((p) => !p)}
+              mobileLibraryOpen={mobileLibraryOpen}
               onToggleLibrary={() => setMobileLibraryOpen((o) => !o)}
+              mobileInspectorOpen={mobileInspectorOpen}
               onToggleInspector={() => setMobileInspectorOpen((o) => !o)}
             />
             <div

--- a/src/collage-studio/CollageStudioApp.tsx
+++ b/src/collage-studio/CollageStudioApp.tsx
@@ -63,9 +63,15 @@ function CollageStudioApp() {
               previewMode={previewMode}
               onTogglePreview={() => setPreviewMode((p) => !p)}
               mobileLibraryOpen={mobileLibraryOpen}
-              onToggleLibrary={() => setMobileLibraryOpen((o) => !o)}
+              onToggleLibrary={() => {
+                setMobileLibraryOpen((o) => !o)
+                setMobileInspectorOpen(false)
+              }}
               mobileInspectorOpen={mobileInspectorOpen}
-              onToggleInspector={() => setMobileInspectorOpen((o) => !o)}
+              onToggleInspector={() => {
+                setMobileInspectorOpen((o) => !o)
+                setMobileLibraryOpen(false)
+              }}
             />
             <div
               className="app-body"

--- a/src/collage-studio/CollageStudioApp.tsx
+++ b/src/collage-studio/CollageStudioApp.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import { CanvasEditor } from './components/CanvasEditor'
 import { InspectorPanel } from './components/InspectorPanel'
 import { LibraryPanel } from './components/LibraryPanel'
-import { QuickStartTemplates } from './components/QuickStartTemplates'
 import { Toolbar } from './components/Toolbar'
 import { CollageStoreProvider } from './state/collageStore'
 import { DialogProvider } from './state/dialogStore'
@@ -40,7 +39,6 @@ function CollageStudioApp() {
                 <LibraryPanel />
               </div>
               <div className="app-center">
-                <QuickStartTemplates />
                 <CanvasEditor previewMode={previewMode} />
               </div>
               <div className={`inspector-panel-wrap${mobileInspectorOpen ? ' open' : ''}`}>

--- a/src/collage-studio/CollageStudioApp.tsx
+++ b/src/collage-studio/CollageStudioApp.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { CanvasEditor } from './components/CanvasEditor'
 import { InspectorPanel } from './components/InspectorPanel'
 import { LibraryPanel } from './components/LibraryPanel'
@@ -14,6 +14,37 @@ function CollageStudioApp() {
   // are always-visible flex columns and these flags have no visual effect.
   const [mobileLibraryOpen, setMobileLibraryOpen] = useState(false)
   const [mobileInspectorOpen, setMobileInspectorOpen] = useState(false)
+
+  const [libraryWidth, setLibraryWidth] = useState(280)
+  const [inspectorWidth, setInspectorWidth] = useState(300)
+  const resizeStartRef = useRef<{ startX: number; startWidth: number } | null>(null)
+
+  const startResizeLibrary = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    resizeStartRef.current = { startX: e.clientX, startWidth: libraryWidth }
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }, [libraryWidth])
+
+  const onResizeLibraryMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const start = resizeStartRef.current
+    if (!start) return
+    setLibraryWidth(Math.max(200, Math.min(520, start.startWidth + (e.clientX - start.startX))))
+  }, [])
+
+  const startResizeInspector = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    resizeStartRef.current = { startX: e.clientX, startWidth: inspectorWidth }
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }, [inspectorWidth])
+
+  const onResizeInspectorMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const start = resizeStartRef.current
+    if (!start) return
+    setInspectorWidth(Math.max(220, Math.min(520, start.startWidth - (e.clientX - start.startX))))
+  }, [])
+
+  const endResize = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    resizeStartRef.current = null
+    e.currentTarget.releasePointerCapture(e.pointerId)
+  }, [])
 
   return (
     <ImagePoolProvider>
@@ -34,13 +65,28 @@ function CollageStudioApp() {
               onToggleLibrary={() => setMobileLibraryOpen((o) => !o)}
               onToggleInspector={() => setMobileInspectorOpen((o) => !o)}
             />
-            <div className="app-body">
+            <div
+              className="app-body"
+              style={{ '--library-width': `${libraryWidth}px`, '--inspector-width': `${inspectorWidth}px` } as React.CSSProperties}
+            >
               <div className={`library-panel-wrap${mobileLibraryOpen ? ' open' : ''}`}>
                 <LibraryPanel />
               </div>
+              <div
+                className="resize-handle"
+                onPointerDown={startResizeLibrary}
+                onPointerMove={onResizeLibraryMove}
+                onPointerUp={endResize}
+              />
               <div className="app-center">
                 <CanvasEditor previewMode={previewMode} />
               </div>
+              <div
+                className="resize-handle"
+                onPointerDown={startResizeInspector}
+                onPointerMove={onResizeInspectorMove}
+                onPointerUp={endResize}
+              />
               <div className={`inspector-panel-wrap${mobileInspectorOpen ? ' open' : ''}`}>
                 <InspectorPanel />
               </div>

--- a/src/collage-studio/collage-studio.css
+++ b/src/collage-studio/collage-studio.css
@@ -186,11 +186,32 @@
 /* ---- tabs ---- */
 .collage-studio-page .tabs-bar {
   display: flex;
-  gap: 2px;
-  padding: 0 8px;
+  align-items: center;
+  gap: 6px;
+  padding: 0 6px;
   background: #1c1c1f;
   border-bottom: 1px solid #333;
+}
+.collage-studio-page .tabs-bar-tabs {
+  display: flex;
+  gap: 2px;
   overflow-x: auto;
+  flex: 1;
+  min-width: 0;
+}
+.collage-studio-page .mobile-panel-icon-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  flex-shrink: 0;
+  color: #aaa;
+}
+.collage-studio-page .mobile-panel-icon-toggle.active {
+  color: #3b82f6;
+  border-color: #3b82f6;
 }
 .collage-studio-page .tab {
   display: flex;
@@ -556,16 +577,13 @@
 }
 
 /* ---- mobile: library/inspector become slide-in drawers instead of fixed columns ---- */
-.collage-studio-page .mobile-panel-toggle {
-  display: none;
-}
 .collage-studio-page .library-panel-wrap,
 .collage-studio-page .inspector-panel-wrap {
   display: contents;
 }
 
 @media (max-width: 860px) {
-  .collage-studio-page .mobile-panel-toggle {
+  .collage-studio-page .mobile-panel-icon-toggle {
     display: inline-flex;
   }
   .collage-studio-page .resize-handle {

--- a/src/collage-studio/collage-studio.css
+++ b/src/collage-studio/collage-studio.css
@@ -280,10 +280,34 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 4px;
   margin-bottom: 6px;
+}
+.collage-studio-page .library-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.collage-studio-page .library-header-actions button {
+  padding: 3px 6px;
+  font-size: 11px;
+}
+.collage-studio-page .library-add-btn {
+  border-radius: 50%;
+  width: 22px;
+  height: 22px;
+  padding: 0 !important;
+  font-size: 14px;
+  line-height: 1;
 }
 .collage-studio-page .library-thumb-wrap {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  cursor: grab;
 }
 .collage-studio-page .library-thumb-remove {
   position: absolute;
@@ -303,8 +327,8 @@
 }
 .collage-studio-page .library-thumbs {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
-  gap: 6px;
+  grid-template-columns: repeat(auto-fill, minmax(104px, 1fr));
+  gap: 10px;
   overflow-y: auto;
   flex: 1;
   min-height: 60px;
@@ -315,12 +339,24 @@
   width: 100%;
   aspect-ratio: 1;
   object-fit: cover;
-  cursor: grab;
-  border-radius: 4px;
+  border-radius: 6px;
   border: 1px solid #333;
 }
-.collage-studio-page .library-thumb:hover {
+.collage-studio-page .library-thumb-wrap:hover .library-thumb {
   outline: 2px solid #3b82f6;
+}
+.collage-studio-page .library-thumb-name {
+  font-size: 10px;
+  color: #888;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.collage-studio-page .library-thumbs-hint {
+  font-size: 11px;
+  color: #777;
+  margin: 8px 0 0;
+  line-height: 1.5;
 }
 
 /* ---- canvas editor ---- */

--- a/src/collage-studio/collage-studio.css
+++ b/src/collage-studio/collage-studio.css
@@ -121,6 +121,13 @@
   width: 140px;
   font-size: 12px;
   padding: 1px 4px;
+  /* Explicit, not just relying on the general input[type='text'] rule --
+     that rule didn't apply here since the input previously had no `type`
+     attribute at all, leaving it on the browser's default white-on-white. */
+  background: #1c1c1f;
+  color: #eee;
+  border: 1px solid #45454c;
+  border-radius: 4px;
 }
 .collage-studio-page .tab-close {
   padding: 0 4px;

--- a/src/collage-studio/collage-studio.css
+++ b/src/collage-studio/collage-studio.css
@@ -82,6 +82,107 @@
   flex-direction: column;
 }
 
+/* ---- New ▾ split button ---- */
+.collage-studio-page .new-menu-wrap {
+  position: relative;
+  display: inline-flex;
+}
+.collage-studio-page .new-menu-main {
+  border-right: none;
+  border-radius: 4px 0 0 4px;
+}
+.collage-studio-page .new-menu-caret {
+  border-radius: 0 4px 4px 0;
+  padding: 4px 6px;
+  font-size: 10px;
+}
+.collage-studio-page .new-menu-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 4px;
+  background: #242428;
+  border: 1px solid #444;
+  border-radius: 6px;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  z-index: 50;
+  min-width: 150px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+.collage-studio-page .new-menu-dropdown button {
+  background: transparent;
+  border: none;
+  text-align: left;
+  padding: 6px 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.collage-studio-page .new-menu-dropdown button:hover {
+  background: #333338;
+}
+.collage-studio-page .layout-icon {
+  width: 18px;
+  height: 14px;
+  border: 1px solid #999;
+  border-radius: 2px;
+  flex-shrink: 0;
+  display: grid;
+  gap: 1px;
+}
+.collage-studio-page .layout-icon-twoCol {
+  grid-template-columns: 1fr 1fr;
+}
+.collage-studio-page .layout-icon-twoCol::before {
+  content: '';
+  border-right: 1px solid #999;
+}
+.collage-studio-page .layout-icon-twoRow {
+  grid-template-rows: 1fr 1fr;
+}
+.collage-studio-page .layout-icon-twoRow::before {
+  content: '';
+  border-bottom: 1px solid #999;
+}
+.collage-studio-page .layout-icon-threeCol {
+  grid-template-columns: 1fr 1fr 1fr;
+}
+.collage-studio-page .layout-icon-threeCol::before,
+.collage-studio-page .layout-icon-threeCol::after {
+  content: '';
+  border-right: 1px solid #999;
+}
+.collage-studio-page .layout-icon-twoXTwo {
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+}
+.collage-studio-page .layout-icon-twoXTwo::before {
+  content: '';
+  grid-column: span 2;
+  border-bottom: 1px solid #999;
+}
+.collage-studio-page .layout-icon-twoXTwo::after {
+  content: '';
+  grid-column: span 2;
+  border-left: 1px solid #999;
+  margin-left: 50%;
+}
+.collage-studio-page .layout-icon-threeXThree,
+.collage-studio-page .layout-icon-fourXFour {
+  background-image:
+    linear-gradient(#999 1px, transparent 1px),
+    linear-gradient(90deg, #999 1px, transparent 1px);
+}
+.collage-studio-page .layout-icon-threeXThree {
+  background-size: 33.33% 33.33%;
+}
+.collage-studio-page .layout-icon-fourXFour {
+  background-size: 25% 25%;
+}
+
 /* ---- tabs ---- */
 .collage-studio-page .tabs-bar {
   display: flex;
@@ -223,15 +324,6 @@
 }
 
 /* ---- canvas editor ---- */
-.collage-studio-page .quick-start {
-  display: flex;
-  gap: 6px;
-  align-items: center;
-  padding: 6px 12px;
-  font-size: 12px;
-  color: #aaa;
-  border-bottom: 1px solid #2e2e33;
-}
 .collage-studio-page .canvas-editor {
   flex: 1;
   overflow: auto;

--- a/src/collage-studio/collage-studio.css
+++ b/src/collage-studio/collage-studio.css
@@ -445,8 +445,10 @@
 .collage-studio-page .divider-vertical {
   cursor: row-resize;
 }
-.collage-studio-page .seam-marker {
+.collage-studio-page .insert-add-btn {
   position: absolute;
+  left: 10px;
+  top: 10px;
   width: 26px;
   height: 26px;
   border-radius: 50%;
@@ -462,7 +464,7 @@
   padding: 0;
   transition: transform 0.1s ease;
 }
-.collage-studio-page .seam-marker:hover {
+.collage-studio-page .insert-add-btn:hover {
   background: #2563eb;
   transform: scale(1.15);
 }

--- a/src/collage-studio/collage-studio.css
+++ b/src/collage-studio/collage-studio.css
@@ -379,8 +379,7 @@
   scrollbar-gutter: stable;
   flex: 1;
   min-height: 60px;
-  padding-top: 6px;
-  padding-right: 4px;
+  padding: 6px 6px 0;
   align-content: start;
 }
 .collage-studio-page .library-thumb {

--- a/src/collage-studio/collage-studio.css
+++ b/src/collage-studio/collage-studio.css
@@ -313,22 +313,13 @@
   flex-direction: column;
   padding: 8px;
   overflow: hidden;
+  /* The whole panel is a drop target now (not a dedicated dropzone box) --
+     dropping anywhere here adds to the gallery. */
+  border-top: 2px solid transparent;
 }
-.collage-studio-page .library-dropzone {
-  border: 2px dashed #444;
-  border-radius: 6px;
-  padding: 14px 8px;
-  text-align: center;
-  font-size: 11px;
-  color: #999;
-  cursor: pointer;
-  margin-bottom: 8px;
-}
-.collage-studio-page .library-dropzone:hover,
-.collage-studio-page .library-dropzone.drag-over {
-  border-color: #3b82f6;
-  color: #ccc;
-  background: rgba(59, 130, 246, 0.08);
+.collage-studio-page .library-panel.drag-over {
+  border-top-color: #3b82f6;
+  background: rgba(59, 130, 246, 0.06);
 }
 .collage-studio-page .library-gallery-header {
   display: flex;

--- a/src/collage-studio/collage-studio.css
+++ b/src/collage-studio/collage-studio.css
@@ -384,9 +384,12 @@
   grid-template-columns: repeat(auto-fill, minmax(104px, 1fr));
   gap: 10px;
   overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-gutter: stable;
   flex: 1;
   min-height: 60px;
   padding-top: 6px;
+  padding-right: 4px;
   align-content: start;
 }
 .collage-studio-page .library-thumb {
@@ -417,6 +420,7 @@
 .collage-studio-page .canvas-editor {
   flex: 1;
   overflow: auto;
+  scrollbar-gutter: stable;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -513,7 +517,9 @@
   width: var(--inspector-width, 300px);
   border-left: 1px solid #333;
   overflow-y: auto;
+  scrollbar-gutter: stable;
   padding: 10px;
+  padding-right: 6px;
   display: flex;
   flex-direction: column;
   gap: 14px;
@@ -598,7 +604,10 @@
   gap: 8px;
 }
 
-/* ---- mobile: library/inspector become slide-in drawers instead of fixed columns ---- */
+/* ---- mobile: library/inspector share space with the canvas instead of
+   overlaying it -- at most one of the two is ever open at once (enforced
+   in CollageStudioApp.tsx), so the only states are "library + canvas",
+   "canvas" alone, or "canvas + inspector", never an overlap. ---- */
 .collage-studio-page .library-panel-wrap,
 .collage-studio-page .inspector-panel-wrap {
   display: contents;
@@ -613,32 +622,18 @@
   }
   .collage-studio-page .library-panel-wrap,
   .collage-studio-page .inspector-panel-wrap {
-    display: block;
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    width: min(82vw, 320px);
-    z-index: 50;
-    transition: transform 0.2s ease;
+    display: none;
   }
-  .collage-studio-page .library-panel-wrap {
-    left: 0;
-    transform: translateX(-100%);
-  }
-  .collage-studio-page .library-panel-wrap.open {
-    transform: translateX(0);
-  }
-  .collage-studio-page .inspector-panel-wrap {
-    right: 0;
-    transform: translateX(100%);
-  }
+  .collage-studio-page .library-panel-wrap.open,
   .collage-studio-page .inspector-panel-wrap.open {
-    transform: translateX(0);
+    display: block;
+    width: min(70vw, 300px);
+    flex-shrink: 0;
+    height: 100%;
   }
-  .collage-studio-page .library-panel-wrap .library-panel,
-  .collage-studio-page .inspector-panel-wrap .inspector-panel {
+  .collage-studio-page .library-panel-wrap.open .library-panel,
+  .collage-studio-page .inspector-panel-wrap.open .inspector-panel {
     width: 100%;
     height: 100%;
-    box-shadow: 4px 0 20px rgba(0, 0, 0, 0.5);
   }
 }

--- a/src/collage-studio/collage-studio.css
+++ b/src/collage-studio/collage-studio.css
@@ -14,6 +14,28 @@
   box-sizing: border-box;
 }
 
+/* Dark scrollbars everywhere in this subsystem, matching the design --
+   otherwise these show the OS/browser's light default against a dark UI. */
+.collage-studio-page * {
+  scrollbar-width: thin;
+  scrollbar-color: #4a4a52 #1c1c1f;
+}
+.collage-studio-page *::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+.collage-studio-page *::-webkit-scrollbar-track {
+  background: #1c1c1f;
+}
+.collage-studio-page *::-webkit-scrollbar-thumb {
+  background: #4a4a52;
+  border-radius: 6px;
+  border: 2px solid #1c1c1f;
+}
+.collage-studio-page *::-webkit-scrollbar-thumb:hover {
+  background: #5a5a63;
+}
+
 .collage-studio-page button {
   background: #333338;
   color: #eee;

--- a/src/collage-studio/collage-studio.css
+++ b/src/collage-studio/collage-studio.css
@@ -511,6 +511,28 @@
   background: #2563eb;
   transform: scale(1.15);
 }
+.collage-studio-page .insert-move-handle {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  background: #3b82f6;
+  border: 2px solid white;
+  border-radius: 50%;
+  cursor: grab;
+  z-index: 6;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+}
+.collage-studio-page .insert-resize-handle {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  background: #3b82f6;
+  border: 2px solid white;
+  border-radius: 3px;
+  cursor: nwse-resize;
+  z-index: 6;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+}
 
 /* ---- inspector ---- */
 .collage-studio-page .inspector-panel {

--- a/src/collage-studio/collage-studio.css
+++ b/src/collage-studio/collage-studio.css
@@ -251,9 +251,20 @@
   min-width: 0;
 }
 
+/* ---- resize handles (between library/canvas and canvas/inspector) ---- */
+.collage-studio-page .resize-handle {
+  width: 6px;
+  cursor: col-resize;
+  background: transparent;
+  flex-shrink: 0;
+}
+.collage-studio-page .resize-handle:hover {
+  background: #3b82f6;
+}
+
 /* ---- library ---- */
 .collage-studio-page .library-panel {
-  width: 280px;
+  width: var(--library-width, 280px);
   border-right: 1px solid #333;
   display: flex;
   flex-direction: column;
@@ -447,7 +458,7 @@
 
 /* ---- inspector ---- */
 .collage-studio-page .inspector-panel {
-  width: 300px;
+  width: var(--inspector-width, 300px);
   border-left: 1px solid #333;
   overflow-y: auto;
   padding: 10px;
@@ -547,6 +558,9 @@
 @media (max-width: 860px) {
   .collage-studio-page .mobile-panel-toggle {
     display: inline-flex;
+  }
+  .collage-studio-page .resize-handle {
+    display: none;
   }
   .collage-studio-page .library-panel-wrap,
   .collage-studio-page .inspector-panel-wrap {

--- a/src/collage-studio/collage-studio.css
+++ b/src/collage-studio/collage-studio.css
@@ -444,16 +444,25 @@
   height: 24px;
   padding: 0;
 }
-.collage-studio-page .insert-resize-handle {
+.collage-studio-page .seam-remove {
   position: absolute;
-  width: 14px;
-  height: 14px;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border-radius: 50%;
   background: #3b82f6;
+  color: white;
   border: 2px solid white;
-  border-radius: 3px;
-  cursor: nwse-resize;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.6);
+  cursor: pointer;
   z-index: 6;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+  font-size: 11px;
+  line-height: 1;
+  transition: transform 0.1s ease;
+}
+.collage-studio-page .seam-remove:hover {
+  background: #2563eb;
+  transform: scale(1.15);
 }
 
 /* ---- inspector ---- */

--- a/src/collage-studio/components/CanvasEditor.tsx
+++ b/src/collage-studio/components/CanvasEditor.tsx
@@ -187,8 +187,9 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
           ensureImageLoaded(insert.imageKey, pooled.objectUrl, forceRedraw)
           continue
         }
-        if (insert.shadow?.enabled) {
-          drawInsertShadow(ctx, rect, insert.cornerRadiusPct, insert.shadow, layout.scale)
+        const shadow = insert.shadow ?? doc.insertShadowDefault
+        if (shadow.enabled) {
+          drawInsertShadow(ctx, rect, insert.cornerRadiusPct, shadow, layout.scale)
         }
         drawFeatheredImage(ctx, img, rect, insert.focal, insert.zoom, insert.cornerRadiusPct, insert.featherPx * layout.scale)
         const border = insert.border ?? doc.insertBorderDefault

--- a/src/collage-studio/components/CanvasEditor.tsx
+++ b/src/collage-studio/components/CanvasEditor.tsx
@@ -1,15 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { FocalPoint, ImageRef, Insert } from '../model/collageTypes'
 import { newId } from '../model/collageTypes'
-import {
-  collectDividers,
-  collectFrames,
-  computeCropBox,
-  findAdjacentSeams,
-  rectsAdjacentSeam,
-  resolveRects,
-  type Rect,
-} from '../model/geometry'
+import { collectDividers, collectFrames, computeCropBox, rectsAdjacentSeam, resolveRects, type Rect } from '../model/geometry'
 import { drawCoverCropImage, drawFeatheredImage, drawInsertShadow, strokeRoundedRect } from '../model/canvasRender'
 import { ensureImageLoaded, getCachedImage } from '../model/imageCache'
 import { useCollageStore } from '../state/collageStore'
@@ -108,8 +100,7 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
     const frameRects = resolveRects(tree, interior, gutter)
     const frames = collectFrames(tree)
     const dividers = collectDividers(tree, interior, gutter)
-    const seams = findAdjacentSeams(frameRects, gutter)
-    return { scale, canvasCssW, canvasCssH, extW, gutter, interior, frameRects, frames, dividers, seams }
+    return { scale, canvasCssW, canvasCssH, extW, gutter, interior, frameRects, frames, dividers }
   }, [doc, containerSize, liveRatio])
 
   const insertRects = useMemo(() => {
@@ -607,7 +598,19 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
   const frameCount = Object.keys(layout.frameRects).length
 
   return (
-    <div className="canvas-editor" ref={wrapperRef}>
+    <div
+      className="canvas-editor"
+      ref={wrapperRef}
+      onClick={(e) => {
+        // Only when the click lands on this wrapper itself -- the padding
+        // area around the stage -- not any descendant (stage/canvas clicks
+        // are handled by onCanvasPointerDown, which already selects/
+        // deselects based on what's under the pointer).
+        if (e.target !== e.currentTarget) return
+        selectFrame(null)
+        selectInsert(null)
+      }}
+    >
       <div className="canvas-editor-stage" style={{ width: layout.canvasCssW, height: layout.canvasCssH }}>
         <canvas
           ref={canvasRef}
@@ -631,75 +634,34 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
             />
           ))}
 
-        {!previewMode &&
-          layout.seams.map((seam) => {
-            // A seam only offers "+" while nothing is anchored to it. Once an
-            // insert is created there it can be freely moved away (via its
-            // move handle below), which detaches it from the seam and frees
-            // the "+" up again -- see onInsertMovePointerUp.
-            const occupied = doc.inserts.some(
-              (i) =>
-                i.seam &&
-                ((i.seam.frameIdA === seam.frameIdA && i.seam.frameIdB === seam.frameIdB) ||
-                  (i.seam.frameIdA === seam.frameIdB && i.seam.frameIdB === seam.frameIdA)),
-            )
-            if (occupied) return null
-            return (
-              <button
-                key={`${seam.frameIdA}-${seam.frameIdB}`}
-                className="seam-marker"
-                title="Add insert on this seam"
-                style={{ left: seam.cx - 13, top: seam.cy - 13 }}
-                onClick={() => {
-                  const frameA = layout.frames[seam.frameIdA]
-                  const frameB = layout.frames[seam.frameIdB]
-                  const imageKey = frameA?.image?.imageKey ?? frameB?.image?.imageKey ?? null
-                  const insert: Insert = {
-                    id: newId(),
-                    imageKey,
-                    seam: { frameIdA: seam.frameIdA, frameIdB: seam.frameIdB },
-                    position: null,
-                    sizePct: 0.26,
-                    focal: { x: 0.5, y: 0.5 },
-                    zoom: 1.6,
-                    featherPx: 18,
-                    cornerRadiusPct: 0.08,
-                    border: null,
-                    shadow: null,
-                  }
-                  editDoc((d) => ({ ...d, inserts: [...d.inserts, insert] }))
-                  selectInsert(insert.id)
-                }}
-              >
-                +
-              </button>
-            )
-          })}
+        {!previewMode && (
+          <button
+            className="insert-add-btn"
+            title="Add an insert (drag it into place afterwards)"
+            onClick={() => {
+              const insert: Insert = {
+                id: newId(),
+                imageKey: null,
+                seam: null,
+                position: { cxPct: 0.5, cyPct: 0.5 },
+                sizePct: 0.26,
+                focal: { x: 0.5, y: 0.5 },
+                zoom: 1.6,
+                featherPx: 18,
+                cornerRadiusPct: 0.08,
+                border: null,
+                shadow: null,
+              }
+              editDoc((d) => ({ ...d, inserts: [...d.inserts, insert] }))
+              selectInsert(insert.id)
+            }}
+          >
+            +
+          </button>
+        )}
 
-        {/* Every existing insert gets its own remove-X at its current
-            rendered position, whether it's still seam-anchored or has been
-            freely moved -- unlike the seam "+", this doesn't depend on
-            selection state. */}
-        {!previewMode &&
-          doc.inserts.map((insert) => {
-            const rect = insertRects[insert.id]
-            if (!rect) return null
-            return (
-              <button
-                key={insert.id}
-                className="seam-remove"
-                title="Remove insert"
-                style={{ left: rect.x + rect.w - 11, top: rect.y - 11 }}
-                onClick={() => {
-                  editDoc((d) => ({ ...d, inserts: d.inserts.filter((i) => i.id !== insert.id) }))
-                  if (selectedInsertId === insert.id) selectInsert(null)
-                }}
-              >
-                ✕
-              </button>
-            )
-          })}
-
+        {/* Move/resize/remove controls only for the *selected* insert --
+            wherever it currently is (seam-anchored or freely moved). */}
         {!previewMode && selectedInsertId && insertRects[selectedInsertId] && (
           <>
             <div
@@ -723,6 +685,20 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
               onPointerUp={onInsertResizePointerUp}
               title="Drag to resize"
             />
+            <button
+              className="seam-remove"
+              title="Remove insert"
+              style={{
+                left: insertRects[selectedInsertId].x + insertRects[selectedInsertId].w - 11,
+                top: insertRects[selectedInsertId].y - 11,
+              }}
+              onClick={() => {
+                editDoc((d) => ({ ...d, inserts: d.inserts.filter((i) => i.id !== selectedInsertId) }))
+                selectInsert(null)
+              }}
+            >
+              ✕
+            </button>
           </>
         )}
 

--- a/src/collage-studio/components/CanvasEditor.tsx
+++ b/src/collage-studio/components/CanvasEditor.tsx
@@ -23,8 +23,6 @@ const LIBRARY_DRAG_MIME = 'application/x-collage-image'
 type DragState =
   | { type: 'pan'; frameId: string; pointerId: number; startX: number; startY: number; startFocal: FocalPoint; rect: Rect; img: HTMLImageElement; cropW: number; cropH: number }
   | { type: 'divider'; pointerId: number; splitId: string; orientation: 'horizontal' | 'vertical'; parentRect: Rect }
-  | { type: 'insert-move'; insertId: string; pointerId: number; startX: number; startY: number; startCxPct: number; startCyPct: number; moved: boolean }
-  | { type: 'insert-resize'; insertId: string; pointerId: number; startX: number; startY: number; startSizePct: number }
 
 function hitTest(point: { x: number; y: number }, rects: Record<string, Rect>): string | null {
   for (const [id, r] of Object.entries(rects)) {
@@ -65,8 +63,6 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
   const [tick, setTick] = useState(0)
   const [liveFocal, setLiveFocal] = useState<{ frameId: string; focal: FocalPoint } | null>(null)
   const [liveRatio, setLiveRatio] = useState<{ splitId: string; ratio: number } | null>(null)
-  const [liveInsertPos, setLiveInsertPos] = useState<{ insertId: string; cxPct: number; cyPct: number } | null>(null)
-  const [liveInsertSize, setLiveInsertSize] = useState<{ insertId: string; sizePct: number } | null>(null)
   const forceRedraw = useCallback(() => setTick((t) => t + 1), [])
 
   useEffect(() => {
@@ -107,14 +103,13 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
     if (!doc || !layout) return {}
     const out: Record<string, Rect> = {}
     for (const insert of doc.inserts) {
-      const sizePct = liveInsertSize && liveInsertSize.insertId === insert.id ? liveInsertSize.sizePct : insert.sizePct
-      const size = sizePct * Math.min(layout.canvasCssW, layout.canvasCssH)
+      const size = insert.sizePct * Math.min(layout.canvasCssW, layout.canvasCssH)
       let cx: number
       let cy: number
-      if (liveInsertPos && liveInsertPos.insertId === insert.id) {
-        cx = liveInsertPos.cxPct * layout.canvasCssW
-        cy = liveInsertPos.cyPct * layout.canvasCssH
-      } else if (insert.position) {
+      // `position` (free placement) is no longer settable from the UI --
+      // inserts are seam-anchored only -- but still honored here so any
+      // older doc that has one keeps rendering where it was left.
+      if (insert.position) {
         cx = insert.position.cxPct * layout.canvasCssW
         cy = insert.position.cyPct * layout.canvasCssH
       } else if (insert.seam) {
@@ -128,7 +123,7 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
       out[insert.id] = { x: cx - size / 2, y: cy - size / 2, w: size, h: size }
     }
     return out
-  }, [doc, layout, liveInsertPos, liveInsertSize])
+  }, [doc, layout])
 
   // ---- draw ----
   useEffect(() => {
@@ -216,20 +211,6 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
       const insertId = hitTest(point, insertRects)
       if (insertId) {
         selectInsert(insertId)
-        if (!previewMode) {
-          const rect = insertRects[insertId]
-          dragRef.current = {
-            type: 'insert-move',
-            insertId,
-            pointerId: e.pointerId,
-            startX: point.x,
-            startY: point.y,
-            startCxPct: (rect.x + rect.w / 2) / layout.canvasCssW,
-            startCyPct: (rect.y + rect.h / 2) / layout.canvasCssH,
-            moved: false,
-          }
-          e.currentTarget.setPointerCapture(e.pointerId)
-        }
         return
       }
 
@@ -276,19 +257,6 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
         const newX = Math.max(0, Math.min(1, drag.startFocal.x - (dxCss * scaleX) / drag.img.naturalWidth))
         const newY = Math.max(0, Math.min(1, drag.startFocal.y - (dyCss * scaleY) / drag.img.naturalHeight))
         setLiveFocal({ frameId: drag.frameId, focal: { x: newX, y: newY } })
-        return
-      }
-
-      if (drag.type === 'insert-move') {
-        const box = e.currentTarget.getBoundingClientRect()
-        const x = e.clientX - box.left
-        const y = e.clientY - box.top
-        const dxCss = x - drag.startX
-        const dyCss = y - drag.startY
-        if (Math.abs(dxCss) > 2 || Math.abs(dyCss) > 2) drag.moved = true
-        const newCxPct = Math.max(0, Math.min(1, drag.startCxPct + dxCss / layout.canvasCssW))
-        const newCyPct = Math.max(0, Math.min(1, drag.startCyPct + dyCss / layout.canvasCssH))
-        setLiveInsertPos({ insertId: drag.insertId, cxPct: newCxPct, cyPct: newCyPct })
       }
     },
     [layout],
@@ -305,21 +273,6 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
         setLiveFocal((live) => {
           if (live && live.frameId === drag.frameId) {
             editDoc((d) => ({ ...d, tree: updateFrame(d.tree, drag.frameId, (f) => ({ ...f, image: f.image ? { ...f.image, focal: live.focal } : f.image })) }))
-          }
-          return null
-        })
-        return
-      }
-
-      if (drag.type === 'insert-move') {
-        dragRef.current = null
-        e.currentTarget.releasePointerCapture(e.pointerId)
-        setLiveInsertPos((live) => {
-          if (live && drag.moved) {
-            editDoc((d) => ({
-              ...d,
-              inserts: d.inserts.map((i) => (i.id === live.insertId ? { ...i, position: { cxPct: live.cxPct, cyPct: live.cyPct } } : i)),
-            }))
           }
           return null
         })
@@ -439,50 +392,6 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
     [editDoc],
   )
 
-  // ---- insert resize handle (DOM overlay) ----
-  const beginInsertResize = useCallback((e: React.PointerEvent<HTMLDivElement>, insertId: string, startSizePct: number) => {
-    e.stopPropagation()
-    const canvasBox = canvasRef.current?.getBoundingClientRect()
-    if (!canvasBox) return
-    dragRef.current = {
-      type: 'insert-resize',
-      insertId,
-      pointerId: e.pointerId,
-      startX: e.clientX - canvasBox.left,
-      startY: e.clientY - canvasBox.top,
-      startSizePct,
-    }
-    e.currentTarget.setPointerCapture(e.pointerId)
-  }, [])
-
-  const onInsertResizePointerMove = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      const drag = dragRef.current
-      if (!drag || drag.type !== 'insert-resize' || !layout || !canvasRef.current) return
-      const canvasBox = canvasRef.current.getBoundingClientRect()
-      const x = e.clientX - canvasBox.left
-      const y = e.clientY - canvasBox.top
-      const delta = ((x - drag.startX) + (y - drag.startY)) / 2
-      const newSizePct = Math.max(0.05, Math.min(0.6, drag.startSizePct + delta / Math.min(layout.canvasCssW, layout.canvasCssH)))
-      setLiveInsertSize({ insertId: drag.insertId, sizePct: newSizePct })
-    },
-    [layout],
-  )
-
-  const onInsertResizePointerUp = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      const drag = dragRef.current
-      if (!drag || drag.type !== 'insert-resize') return
-      dragRef.current = null
-      e.currentTarget.releasePointerCapture(e.pointerId)
-      setLiveInsertSize((live) => {
-        if (live) editDoc((d) => ({ ...d, inserts: d.inserts.map((i) => (i.id === live.insertId ? { ...i, sizePct: live.sizePct } : i)) }))
-        return null
-      })
-    },
-    [editDoc],
-  )
-
   if (!doc || !layout) {
     return (
       <div className="canvas-editor-empty" ref={wrapperRef}>
@@ -493,7 +402,6 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
 
   const selectedRect = selectedFrameId ? layout.frameRects[selectedFrameId] : null
   const selectedFrame = selectedFrameId ? layout.frames[selectedFrameId] : null
-  const selectedInsertRect = selectedInsertId ? insertRects[selectedInsertId] : null
   const frameCount = Object.keys(layout.frameRects).length
 
   return (
@@ -521,47 +429,66 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
           ))}
 
         {!previewMode &&
-          layout.seams.map((seam) => (
-            <button
-              key={`${seam.frameIdA}-${seam.frameIdB}`}
-              className="seam-marker"
-              title="Add insert on this seam (drag it anywhere afterward)"
-              style={{ left: seam.cx - 13, top: seam.cy - 13 }}
-              onClick={() => {
-                const frameA = layout.frames[seam.frameIdA]
-                const frameB = layout.frames[seam.frameIdB]
-                const imageKey = frameA?.image?.imageKey ?? frameB?.image?.imageKey ?? null
-                const insert: Insert = {
-                  id: newId(),
-                  imageKey,
-                  seam: { frameIdA: seam.frameIdA, frameIdB: seam.frameIdB },
-                  position: null,
-                  sizePct: 0.26,
-                  focal: { x: 0.5, y: 0.5 },
-                  zoom: 1.6,
-                  featherPx: 18,
-                  cornerRadiusPct: 0.08,
-                  border: null,
-                  shadow: null,
-                }
-                editDoc((d) => ({ ...d, inserts: [...d.inserts, insert] }))
-                selectInsert(insert.id)
-              }}
-            >
-              +
-            </button>
-          ))}
-
-        {!previewMode && selectedInsertRect && selectedInsertId && (
-          <div
-            className="insert-resize-handle"
-            style={{ left: selectedInsertRect.x + selectedInsertRect.w - 6, top: selectedInsertRect.y + selectedInsertRect.h - 6 }}
-            onPointerDown={(e) => beginInsertResize(e, selectedInsertId, doc.inserts.find((i) => i.id === selectedInsertId)?.sizePct ?? 0.26)}
-            onPointerMove={onInsertResizePointerMove}
-            onPointerUp={onInsertResizePointerUp}
-            title="Drag to resize"
-          />
-        )}
+          layout.seams.map((seam) => {
+            // At most one insert per seam -- clicking "+" creates it, and its
+            // own small remove button (rendered at the seam position once
+            // it exists) takes the "+" marker's place until it's removed.
+            const existing = doc.inserts.find(
+              (i) =>
+                i.seam &&
+                ((i.seam.frameIdA === seam.frameIdA && i.seam.frameIdB === seam.frameIdB) ||
+                  (i.seam.frameIdA === seam.frameIdB && i.seam.frameIdB === seam.frameIdA)),
+            )
+            const key = `${seam.frameIdA}-${seam.frameIdB}`
+            if (existing) {
+              const rect = insertRects[existing.id]
+              if (!rect) return null
+              return (
+                <button
+                  key={key}
+                  className="seam-remove"
+                  title="Remove insert"
+                  style={{ left: rect.x + rect.w - 11, top: rect.y - 11 }}
+                  onClick={() => {
+                    editDoc((d) => ({ ...d, inserts: d.inserts.filter((i) => i.id !== existing.id) }))
+                    if (selectedInsertId === existing.id) selectInsert(null)
+                  }}
+                >
+                  ✕
+                </button>
+              )
+            }
+            return (
+              <button
+                key={key}
+                className="seam-marker"
+                title="Add insert on this seam"
+                style={{ left: seam.cx - 13, top: seam.cy - 13 }}
+                onClick={() => {
+                  const frameA = layout.frames[seam.frameIdA]
+                  const frameB = layout.frames[seam.frameIdB]
+                  const imageKey = frameA?.image?.imageKey ?? frameB?.image?.imageKey ?? null
+                  const insert: Insert = {
+                    id: newId(),
+                    imageKey,
+                    seam: { frameIdA: seam.frameIdA, frameIdB: seam.frameIdB },
+                    position: null,
+                    sizePct: 0.26,
+                    focal: { x: 0.5, y: 0.5 },
+                    zoom: 1.6,
+                    featherPx: 18,
+                    cornerRadiusPct: 0.08,
+                    border: null,
+                    shadow: null,
+                  }
+                  editDoc((d) => ({ ...d, inserts: [...d.inserts, insert] }))
+                  selectInsert(insert.id)
+                }}
+              >
+                +
+              </button>
+            )
+          })}
 
         {!previewMode && selectedRect && selectedFrameId && (
           <div className="frame-toolbar" style={{ left: selectedRect.x + selectedRect.w - 4, top: selectedRect.y + 4 }}>

--- a/src/collage-studio/components/CanvasEditor.tsx
+++ b/src/collage-studio/components/CanvasEditor.tsx
@@ -23,6 +23,9 @@ const LIBRARY_DRAG_MIME = 'application/x-collage-image'
 type DragState =
   | { type: 'pan'; frameId: string; pointerId: number; startX: number; startY: number; startFocal: FocalPoint; rect: Rect; img: HTMLImageElement; cropW: number; cropH: number }
   | { type: 'divider'; pointerId: number; splitId: string; orientation: 'horizontal' | 'vertical'; parentRect: Rect }
+  | { type: 'insert-pan'; insertId: string; pointerId: number; startX: number; startY: number; startFocal: FocalPoint; rect: Rect; img: HTMLImageElement; cropW: number; cropH: number }
+  | { type: 'insert-move'; insertId: string; pointerId: number; startX: number; startY: number; startCxPct: number; startCyPct: number }
+  | { type: 'insert-resize'; insertId: string; pointerId: number; startX: number; startY: number; startSizePct: number }
 
 function hitTest(point: { x: number; y: number }, rects: Record<string, Rect>): string | null {
   for (const [id, r] of Object.entries(rects)) {
@@ -70,6 +73,9 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
   const [tick, setTick] = useState(0)
   const [liveFocal, setLiveFocal] = useState<{ frameId: string; focal: FocalPoint } | null>(null)
   const [liveRatio, setLiveRatio] = useState<{ splitId: string; ratio: number } | null>(null)
+  const [liveInsertFocal, setLiveInsertFocal] = useState<{ insertId: string; focal: FocalPoint } | null>(null)
+  const [liveInsertPos, setLiveInsertPos] = useState<{ insertId: string; cxPct: number; cyPct: number } | null>(null)
+  const [liveInsertSize, setLiveInsertSize] = useState<{ insertId: string; sizePct: number } | null>(null)
   const forceRedraw = useCallback(() => setTick((t) => t + 1), [])
 
   useEffect(() => {
@@ -110,13 +116,17 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
     if (!doc || !layout) return {}
     const out: Record<string, Rect> = {}
     for (const insert of doc.inserts) {
-      const size = insert.sizePct * Math.min(layout.canvasCssW, layout.canvasCssH)
+      const sizePct = liveInsertSize && liveInsertSize.insertId === insert.id ? liveInsertSize.sizePct : insert.sizePct
+      const size = sizePct * Math.min(layout.canvasCssW, layout.canvasCssH)
       let cx: number
       let cy: number
-      // `position` (free placement) is no longer settable from the UI --
-      // inserts are seam-anchored only -- but still honored here so any
-      // older doc that has one keeps rendering where it was left.
-      if (insert.position) {
+      // Seam-anchored by default (created via the seam "+"), but the move
+      // handle can drag it anywhere -- once it has a `position` that takes
+      // over from the seam anchor.
+      if (liveInsertPos && liveInsertPos.insertId === insert.id) {
+        cx = liveInsertPos.cxPct * layout.canvasCssW
+        cy = liveInsertPos.cyPct * layout.canvasCssH
+      } else if (insert.position) {
         cx = insert.position.cxPct * layout.canvasCssW
         cy = insert.position.cyPct * layout.canvasCssH
       } else if (insert.seam) {
@@ -130,7 +140,7 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
       out[insert.id] = { x: cx - size / 2, y: cy - size / 2, w: size, h: size }
     }
     return out
-  }, [doc, layout])
+  }, [doc, layout, liveInsertPos, liveInsertSize])
 
   // ---- draw ----
   useEffect(() => {
@@ -189,11 +199,12 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
           ensureImageLoaded(insert.imageKey, pooled.objectUrl, forceRedraw)
           continue
         }
+        const insertFocal = liveInsertFocal && liveInsertFocal.insertId === insert.id ? liveInsertFocal.focal : insert.focal
         const shadow = insert.shadow ?? doc.insertShadowDefault
         if (shadow.enabled) {
           drawInsertShadow(ctx, rect, insert.cornerRadiusPct, shadow, layout.scale)
         }
-        drawFeatheredImage(ctx, img, rect, insert.focal, insert.zoom, insert.cornerRadiusPct, insert.featherPx * layout.scale)
+        drawFeatheredImage(ctx, img, rect, insertFocal, insert.zoom, insert.cornerRadiusPct, insert.featherPx * layout.scale)
         const border = insert.border ?? doc.insertBorderDefault
         if (border?.enabled) strokeRoundedRect(ctx, rect, insert.cornerRadiusPct, border.color, border.width * layout.scale)
         if (!previewMode && insert.id === selectedInsertId) {
@@ -206,7 +217,7 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
         }
       }
     }
-  }, [doc, layout, selectedFrameId, selectedInsertId, tick, liveFocal, insertRects, forceRedraw, pool, previewMode])
+  }, [doc, layout, selectedFrameId, selectedInsertId, tick, liveFocal, liveInsertFocal, insertRects, forceRedraw, pool, previewMode])
 
   // ---- pointer interaction on the canvas itself (select / pan / move insert) ----
   const onCanvasPointerDown = useCallback(
@@ -218,6 +229,25 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
       const insertId = hitTest(point, insertRects)
       if (insertId) {
         selectInsert(insertId)
+        const insert = doc.inserts.find((i) => i.id === insertId)
+        if (!insert?.imageKey) return
+        const img = getCachedImage(insert.imageKey)
+        if (!img) return
+        const rect = insertRects[insertId]
+        const cropBox = computeCropBox(img.naturalWidth, img.naturalHeight, rect.w, rect.h, insert.focal, insert.zoom)
+        dragRef.current = {
+          type: 'insert-pan',
+          insertId,
+          pointerId: e.pointerId,
+          startX: point.x,
+          startY: point.y,
+          startFocal: insert.focal,
+          rect,
+          img,
+          cropW: cropBox.w,
+          cropH: cropBox.h,
+        }
+        e.currentTarget.setPointerCapture(e.pointerId)
         return
       }
 
@@ -264,6 +294,20 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
         const newX = Math.max(0, Math.min(1, drag.startFocal.x - (dxCss * scaleX) / drag.img.naturalWidth))
         const newY = Math.max(0, Math.min(1, drag.startFocal.y - (dyCss * scaleY) / drag.img.naturalHeight))
         setLiveFocal({ frameId: drag.frameId, focal: { x: newX, y: newY } })
+        return
+      }
+
+      if (drag.type === 'insert-pan') {
+        const box = e.currentTarget.getBoundingClientRect()
+        const x = e.clientX - box.left
+        const y = e.clientY - box.top
+        const dxCss = x - drag.startX
+        const dyCss = y - drag.startY
+        const scaleX = drag.cropW / drag.rect.w
+        const scaleY = drag.cropH / drag.rect.h
+        const newX = Math.max(0, Math.min(1, drag.startFocal.x - (dxCss * scaleX) / drag.img.naturalWidth))
+        const newY = Math.max(0, Math.min(1, drag.startFocal.y - (dyCss * scaleY) / drag.img.naturalHeight))
+        setLiveInsertFocal({ insertId: drag.insertId, focal: { x: newX, y: newY } })
       }
     },
     [layout],
@@ -283,6 +327,18 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
           }
           return null
         })
+        return
+      }
+
+      if (drag.type === 'insert-pan') {
+        dragRef.current = null
+        e.currentTarget.releasePointerCapture(e.pointerId)
+        setLiveInsertFocal((live) => {
+          if (live && live.insertId === drag.insertId) {
+            editDoc((d) => ({ ...d, inserts: d.inserts.map((i) => (i.id === live.insertId ? { ...i, focal: live.focal } : i)) }))
+          }
+          return null
+        })
       }
     },
     [editDoc],
@@ -296,22 +352,33 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
     const handler = (e: WheelEvent) => {
       const box = canvas.getBoundingClientRect()
       const point = { x: e.clientX - box.left, y: e.clientY - box.top }
-      const frameId = hitTest(point, layout.frameRects)
-      if (!frameId) return
-      const frame = layout.frames[frameId]
-      if (!frame?.image) return
-      e.preventDefault()
       // Multiplicative (not additive) step -- with MAX_ZOOM this high, a fixed
       // +/-0.1 per tick would take hundreds of scroll ticks to reach the top
       // of the range. A proportional step stays fine-grained near 1x and
       // still reaches high zoom quickly.
       const factor = e.deltaY > 0 ? 1 / 1.1 : 1.1
+
+      const insertId = hitTest(point, insertRects)
+      if (insertId) {
+        const insert = doc.inserts.find((i) => i.id === insertId)
+        if (!insert?.imageKey) return
+        e.preventDefault()
+        const nextZoom = Math.max(1, Math.min(MAX_ZOOM, insert.zoom * factor))
+        editDoc((d) => ({ ...d, inserts: d.inserts.map((i) => (i.id === insertId ? { ...i, zoom: nextZoom } : i)) }))
+        return
+      }
+
+      const frameId = hitTest(point, layout.frameRects)
+      if (!frameId) return
+      const frame = layout.frames[frameId]
+      if (!frame?.image) return
+      e.preventDefault()
       const nextZoom = Math.max(1, Math.min(MAX_ZOOM, frame.image.zoom * factor))
       editDoc((d) => ({ ...d, tree: updateFrame(d.tree, frameId, (f) => ({ ...f, image: f.image ? { ...f.image, zoom: nextZoom } : f.image })) }))
     }
     canvas.addEventListener('wheel', handler, { passive: false })
     return () => canvas.removeEventListener('wheel', handler)
-  }, [doc, layout, editDoc])
+  }, [doc, layout, insertRects, editDoc])
 
   const assignImageToDropTarget = useCallback(
     (imageKey: string, insertId: string | null, frameId: string | null) => {
@@ -403,6 +470,103 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
     [editDoc],
   )
 
+  // ---- insert move handle (DOM overlay, top-left anchor) ----
+  const beginInsertMove = useCallback((e: React.PointerEvent<HTMLDivElement>, insertId: string, rect: Rect) => {
+    e.stopPropagation()
+    const canvasBox = canvasRef.current?.getBoundingClientRect()
+    if (!canvasBox || !layout) return
+    dragRef.current = {
+      type: 'insert-move',
+      insertId,
+      pointerId: e.pointerId,
+      startX: e.clientX - canvasBox.left,
+      startY: e.clientY - canvasBox.top,
+      startCxPct: (rect.x + rect.w / 2) / layout.canvasCssW,
+      startCyPct: (rect.y + rect.h / 2) / layout.canvasCssH,
+    }
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }, [layout])
+
+  const onInsertMovePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current
+      if (!drag || drag.type !== 'insert-move' || !layout || !canvasRef.current) return
+      const canvasBox = canvasRef.current.getBoundingClientRect()
+      const x = e.clientX - canvasBox.left
+      const y = e.clientY - canvasBox.top
+      const newCxPct = Math.max(0, Math.min(1, drag.startCxPct + (x - drag.startX) / layout.canvasCssW))
+      const newCyPct = Math.max(0, Math.min(1, drag.startCyPct + (y - drag.startY) / layout.canvasCssH))
+      setLiveInsertPos({ insertId: drag.insertId, cxPct: newCxPct, cyPct: newCyPct })
+    },
+    [layout],
+  )
+
+  const onInsertMovePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current
+      if (!drag || drag.type !== 'insert-move') return
+      dragRef.current = null
+      e.currentTarget.releasePointerCapture(e.pointerId)
+      setLiveInsertPos((live) => {
+        if (live) {
+          // Detach from its birth seam once freely positioned -- otherwise
+          // that seam would look permanently "occupied" (no "+" marker) even
+          // though the insert has moved away from it.
+          editDoc((d) => ({
+            ...d,
+            inserts: d.inserts.map((i) => (i.id === live.insertId ? { ...i, seam: null, position: { cxPct: live.cxPct, cyPct: live.cyPct } } : i)),
+          }))
+        }
+        return null
+      })
+    },
+    [editDoc],
+  )
+
+  // ---- insert resize handle (DOM overlay, bottom-right anchor) ----
+  const beginInsertResize = useCallback((e: React.PointerEvent<HTMLDivElement>, insertId: string, startSizePct: number) => {
+    e.stopPropagation()
+    const canvasBox = canvasRef.current?.getBoundingClientRect()
+    if (!canvasBox) return
+    dragRef.current = {
+      type: 'insert-resize',
+      insertId,
+      pointerId: e.pointerId,
+      startX: e.clientX - canvasBox.left,
+      startY: e.clientY - canvasBox.top,
+      startSizePct,
+    }
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }, [])
+
+  const onInsertResizePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current
+      if (!drag || drag.type !== 'insert-resize' || !layout || !canvasRef.current) return
+      const canvasBox = canvasRef.current.getBoundingClientRect()
+      const x = e.clientX - canvasBox.left
+      const y = e.clientY - canvasBox.top
+      const delta = ((x - drag.startX) + (y - drag.startY)) / 2
+      const newSizePct = Math.max(0.05, Math.min(0.6, drag.startSizePct + delta / Math.min(layout.canvasCssW, layout.canvasCssH)))
+      setLiveInsertSize({ insertId: drag.insertId, sizePct: newSizePct })
+    },
+    [layout],
+  )
+
+  const onInsertResizePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current
+      if (!drag || drag.type !== 'insert-resize') return
+      dragRef.current = null
+      e.currentTarget.releasePointerCapture(e.pointerId)
+      setLiveInsertSize((live) => {
+        if (live) editDoc((d) => ({ ...d, inserts: d.inserts.map((i) => (i.id === live.insertId ? { ...i, sizePct: live.sizePct } : i)) }))
+        return null
+      })
+    },
+    [editDoc],
+  )
+
   if (!doc || !layout) {
     return (
       <div className="canvas-editor-empty" ref={wrapperRef}>
@@ -441,37 +605,20 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
 
         {!previewMode &&
           layout.seams.map((seam) => {
-            // At most one insert per seam -- clicking "+" creates it, and its
-            // own small remove button (rendered at the seam position once
-            // it exists) takes the "+" marker's place until it's removed.
-            const existing = doc.inserts.find(
+            // A seam only offers "+" while nothing is anchored to it. Once an
+            // insert is created there it can be freely moved away (via its
+            // move handle below), which detaches it from the seam and frees
+            // the "+" up again -- see onInsertMovePointerUp.
+            const occupied = doc.inserts.some(
               (i) =>
                 i.seam &&
                 ((i.seam.frameIdA === seam.frameIdA && i.seam.frameIdB === seam.frameIdB) ||
                   (i.seam.frameIdA === seam.frameIdB && i.seam.frameIdB === seam.frameIdA)),
             )
-            const key = `${seam.frameIdA}-${seam.frameIdB}`
-            if (existing) {
-              const rect = insertRects[existing.id]
-              if (!rect) return null
-              return (
-                <button
-                  key={key}
-                  className="seam-remove"
-                  title="Remove insert"
-                  style={{ left: rect.x + rect.w - 11, top: rect.y - 11 }}
-                  onClick={() => {
-                    editDoc((d) => ({ ...d, inserts: d.inserts.filter((i) => i.id !== existing.id) }))
-                    if (selectedInsertId === existing.id) selectInsert(null)
-                  }}
-                >
-                  ✕
-                </button>
-              )
-            }
+            if (occupied) return null
             return (
               <button
-                key={key}
+                key={`${seam.frameIdA}-${seam.frameIdB}`}
                 className="seam-marker"
                 title="Add insert on this seam"
                 style={{ left: seam.cx - 13, top: seam.cy - 13 }}
@@ -500,6 +647,56 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
               </button>
             )
           })}
+
+        {/* Every existing insert gets its own remove-X at its current
+            rendered position, whether it's still seam-anchored or has been
+            freely moved -- unlike the seam "+", this doesn't depend on
+            selection state. */}
+        {!previewMode &&
+          doc.inserts.map((insert) => {
+            const rect = insertRects[insert.id]
+            if (!rect) return null
+            return (
+              <button
+                key={insert.id}
+                className="seam-remove"
+                title="Remove insert"
+                style={{ left: rect.x + rect.w - 11, top: rect.y - 11 }}
+                onClick={() => {
+                  editDoc((d) => ({ ...d, inserts: d.inserts.filter((i) => i.id !== insert.id) }))
+                  if (selectedInsertId === insert.id) selectInsert(null)
+                }}
+              >
+                ✕
+              </button>
+            )
+          })}
+
+        {!previewMode && selectedInsertId && insertRects[selectedInsertId] && (
+          <>
+            <div
+              className="insert-move-handle"
+              style={{ left: insertRects[selectedInsertId].x - 6, top: insertRects[selectedInsertId].y - 6 }}
+              onPointerDown={(e) => beginInsertMove(e, selectedInsertId, insertRects[selectedInsertId])}
+              onPointerMove={onInsertMovePointerMove}
+              onPointerUp={onInsertMovePointerUp}
+              title="Drag to move"
+            />
+            <div
+              className="insert-resize-handle"
+              style={{
+                left: insertRects[selectedInsertId].x + insertRects[selectedInsertId].w - 6,
+                top: insertRects[selectedInsertId].y + insertRects[selectedInsertId].h - 6,
+              }}
+              onPointerDown={(e) =>
+                beginInsertResize(e, selectedInsertId, doc.inserts.find((i) => i.id === selectedInsertId)?.sizePct ?? 0.26)
+              }
+              onPointerMove={onInsertResizePointerMove}
+              onPointerUp={onInsertResizePointerUp}
+              title="Drag to resize"
+            />
+          </>
+        )}
 
         {!previewMode && selectedRect && selectedFrameId && (
           <div className="frame-toolbar" style={{ left: selectedRect.x + selectedRect.w - 4, top: selectedRect.y + 4 }}>

--- a/src/collage-studio/components/CanvasEditor.tsx
+++ b/src/collage-studio/components/CanvasEditor.tsx
@@ -606,6 +606,13 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
               ⇄
             </button>
             <button
+              title="Clear image from this frame"
+              disabled={!selectedFrame?.image}
+              onClick={() => editDoc((d) => ({ ...d, tree: updateFrame(d.tree, selectedFrameId, (f) => ({ ...f, image: null })) }))}
+            >
+              ⌫
+            </button>
+            <button
               title="Remove this frame"
               disabled={frameCount <= 1}
               onClick={() => {

--- a/src/collage-studio/components/CanvasEditor.tsx
+++ b/src/collage-studio/components/CanvasEditor.tsx
@@ -344,6 +344,33 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
     [editDoc],
   )
 
+  // Double-click an image (frame or insert) to reset it back to a plain
+  // fit -- zoom 1, centered focal -- undoing any amount of zoom/pan in one step.
+  const onCanvasDoubleClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (!layout) return
+      const box = e.currentTarget.getBoundingClientRect()
+      const point = { x: e.clientX - box.left, y: e.clientY - box.top }
+
+      const insertId = hitTest(point, insertRects)
+      if (insertId) {
+        editDoc((d) => ({
+          ...d,
+          inserts: d.inserts.map((i) => (i.id === insertId ? { ...i, zoom: 1, focal: { x: 0.5, y: 0.5 } } : i)),
+        }))
+        return
+      }
+
+      const frameId = hitTest(point, layout.frameRects)
+      if (!frameId) return
+      editDoc((d) => ({
+        ...d,
+        tree: updateFrame(d.tree, frameId, (f) => (f.image ? { ...f, image: { ...f.image, zoom: 1, focal: { x: 0.5, y: 0.5 } } } : f)),
+      }))
+    },
+    [layout, insertRects, editDoc],
+  )
+
   // Native (non-React) listener: React's onWheel is registered passive on the
   // root container, so e.preventDefault() there can't stop page scroll.
   useEffect(() => {
@@ -587,6 +614,7 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
           onPointerDown={onCanvasPointerDown}
           onPointerMove={onCanvasPointerMove}
           onPointerUp={onCanvasPointerUp}
+          onDoubleClick={onCanvasDoubleClick}
           onDragOver={(e) => e.preventDefault()}
           onDrop={onDrop}
         />

--- a/src/collage-studio/components/CanvasEditor.tsx
+++ b/src/collage-studio/components/CanvasEditor.tsx
@@ -31,7 +31,7 @@ function hitTest(point: { x: number; y: number }, rects: Record<string, Rect>): 
   return null
 }
 
-function drawPlaceholder(ctx: CanvasRenderingContext2D, rect: Rect, label: string) {
+function drawPlaceholder(ctx: CanvasRenderingContext2D, rect: Rect, label?: string) {
   if (rect.w <= 4 || rect.h <= 4) return
   ctx.save()
   ctx.fillStyle = '#2a2a2e'
@@ -41,13 +41,20 @@ function drawPlaceholder(ctx: CanvasRenderingContext2D, rect: Rect, label: strin
   ctx.lineWidth = 1.5
   ctx.strokeRect(rect.x + 4, rect.y + 4, rect.w - 8, rect.h - 8)
   ctx.setLineDash([])
-  ctx.fillStyle = '#888'
-  ctx.font = '13px system-ui, sans-serif'
-  ctx.textAlign = 'center'
-  ctx.textBaseline = 'middle'
-  if (rect.w > 60 && rect.h > 20) ctx.fillText(label, rect.x + rect.w / 2, rect.y + rect.h / 2)
+  if (label) {
+    ctx.fillStyle = '#888'
+    ctx.font = '13px system-ui, sans-serif'
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    if (rect.w > 60 && rect.h > 20) ctx.fillText(label, rect.x + rect.w / 2, rect.y + rect.h / 2)
+  }
   ctx.restore()
 }
+
+// Matches the CSS mobile breakpoint (collage-studio.css) -- below it, "Drop
+// image here" isn't useful copy (drag-and-drop isn't the primary mobile
+// interaction) and just wastes space on an already-small frame.
+const MOBILE_BREAKPOINT = 860
 
 interface CanvasEditorProps {
   previewMode: boolean
@@ -161,7 +168,7 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
             drawPlaceholder(ctx, rect, 'Missing image — drop it in the library')
           }
         } else {
-          drawPlaceholder(ctx, rect, 'Drop image here')
+          drawPlaceholder(ctx, rect, containerSize.w < MOBILE_BREAKPOINT ? undefined : 'Drop image here')
         }
         if (!previewMode && frameId === selectedFrameId) {
           ctx.save()

--- a/src/collage-studio/components/CanvasEditor.tsx
+++ b/src/collage-studio/components/CanvasEditor.tsx
@@ -301,8 +301,12 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
       const frame = layout.frames[frameId]
       if (!frame?.image) return
       e.preventDefault()
-      const delta = e.deltaY > 0 ? -0.1 : 0.1
-      const nextZoom = Math.max(1, Math.min(MAX_ZOOM, frame.image.zoom + delta))
+      // Multiplicative (not additive) step -- with MAX_ZOOM this high, a fixed
+      // +/-0.1 per tick would take hundreds of scroll ticks to reach the top
+      // of the range. A proportional step stays fine-grained near 1x and
+      // still reaches high zoom quickly.
+      const factor = e.deltaY > 0 ? 1 / 1.1 : 1.1
+      const nextZoom = Math.max(1, Math.min(MAX_ZOOM, frame.image.zoom * factor))
       editDoc((d) => ({ ...d, tree: updateFrame(d.tree, frameId, (f) => ({ ...f, image: f.image ? { ...f.image, zoom: nextZoom } : f.image })) }))
     }
     canvas.addEventListener('wheel', handler, { passive: false })

--- a/src/collage-studio/components/InspectorPanel.tsx
+++ b/src/collage-studio/components/InspectorPanel.tsx
@@ -2,7 +2,6 @@ import { collectFrames } from '../model/geometry'
 import { MAX_ZOOM, type Insert } from '../model/collageTypes'
 import { updateFrame } from '../model/treeOps'
 import { useCollageStore } from '../state/collageStore'
-import { useImagePool } from '../state/imagePoolStore'
 
 const ASPECT_PRESETS: { label: string; ratio: number }[] = [
   { label: '1:1', ratio: 1 },
@@ -50,8 +49,7 @@ function ColorField({ label, value, onChange }: { label: string; value: string; 
 }
 
 export function InspectorPanel() {
-  const { doc, editDoc, selectedFrameId, selectedInsertId, selectInsert } = useCollageStore()
-  const pool = useImagePool()
+  const { doc, editDoc, selectedFrameId, selectedInsertId } = useCollageStore()
 
   if (!doc) return <div className="inspector-panel">No collage open.</div>
 
@@ -275,125 +273,31 @@ export function InspectorPanel() {
       {selectedInsert && (
         <section>
           <h3>Selected insert</h3>
-          <p className="hint">
-            {selectedInsert.imageKey && pool.get(selectedInsert.imageKey)
-              ? `Image: ${pool.get(selectedInsert.imageKey)!.name}`
-              : 'No image assigned -- click or drag a library thumbnail onto it.'}
-            {' '}Drag the insert itself to move it, or its bottom-right handle to resize.
-          </p>
-          <NumberField label="Size %" min={0.1} max={0.5} step={0.01} value={selectedInsert.sizePct} onChange={(v) => updateInsert(selectedInsert.id, { sizePct: v })} />
-          <NumberField label="Zoom" min={1} max={MAX_ZOOM} step={0.05} value={selectedInsert.zoom} onChange={(v) => updateInsert(selectedInsert.id, { zoom: v })} />
-          <NumberField
-            label="Feather (px)"
-            min={0}
-            max={60}
-            step={1}
-            value={selectedInsert.featherPx}
-            onChange={(v) => updateInsert(selectedInsert.id, { featherPx: v })}
-          />
-          <NumberField
-            label="Corner radius %"
-            min={0}
-            max={0.5}
-            step={0.01}
-            value={selectedInsert.cornerRadiusPct}
-            onChange={(v) => updateInsert(selectedInsert.id, { cornerRadiusPct: v })}
-          />
-          <div className="field-row">
-            <NumberField label="Focal X" min={0} max={1} step={0.01} value={selectedInsert.focal.x} onChange={(v) => updateInsert(selectedInsert.id, { focal: { ...selectedInsert.focal, x: v } })} />
-            <NumberField label="Focal Y" min={0} max={1} step={0.01} value={selectedInsert.focal.y} onChange={(v) => updateInsert(selectedInsert.id, { focal: { ...selectedInsert.focal, y: v } })} />
-          </div>
-          <label className="field checkbox">
+          {/* Simplified to just corner radius, matching the new design --
+              size/zoom/feather/focal/border-override/shadow-override are
+              still in the data model (see model/collageTypes.ts) and still
+              apply (via doc-level defaults for border/shadow), just no
+              longer independently editable per-insert from this panel.
+              Move/resize now happens by removing and re-adding the insert
+              (the seam "+"/remove-X on the canvas) rather than drag/resize
+              handles -- see CanvasEditor.tsx. */}
+          <label className="field">
+            <span>Corner radius (0 = square, 50 = circle)</span>
             <input
-              type="checkbox"
-              checked={selectedInsert.border?.enabled ?? doc.insertBorderDefault.enabled}
-              onChange={(e) =>
-                updateInsert(selectedInsert.id, {
-                  border: { enabled: e.target.checked, width: selectedInsert.border?.width ?? doc.insertBorderDefault.width, color: selectedInsert.border?.color ?? doc.insertBorderDefault.color },
-                })
-              }
+              type="range"
+              min={0}
+              max={50}
+              value={Math.round(selectedInsert.cornerRadiusPct * 100)}
+              onChange={(e) => updateInsert(selectedInsert.id, { cornerRadiusPct: Number(e.target.value) / 100 })}
             />
-            <span>Override border (unchecked = use default)</span>
-          </label>
-
-          <h4>Shadow</h4>
-          <label className="field checkbox">
             <input
-              type="checkbox"
-              checked={selectedInsert.shadow?.enabled ?? doc.insertShadowDefault.enabled}
-              onChange={(e) =>
-                updateInsert(selectedInsert.id, {
-                  shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), enabled: e.target.checked },
-                })
-              }
+              type="number"
+              min={0}
+              max={50}
+              value={Math.round(selectedInsert.cornerRadiusPct * 100)}
+              onChange={(e) => updateInsert(selectedInsert.id, { cornerRadiusPct: Number(e.target.value) / 100 })}
             />
-            <span>Override shadow (unchecked = use default)</span>
           </label>
-          <div className="field-row">
-            <NumberField
-              label="Size (offset px)"
-              min={0}
-              max={60}
-              step={1}
-              value={selectedInsert.shadow?.offsetPx ?? doc.insertShadowDefault.offsetPx}
-              onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), offsetPx: v } })}
-            />
-            <NumberField
-              label="Direction (deg)"
-              min={0}
-              max={360}
-              step={1}
-              value={selectedInsert.shadow?.angleDeg ?? doc.insertShadowDefault.angleDeg}
-              onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), angleDeg: v } })}
-            />
-          </div>
-          <div className="field-row">
-            <NumberField
-              label="Blur (px)"
-              min={0}
-              max={60}
-              step={1}
-              value={selectedInsert.shadow?.blurPx ?? doc.insertShadowDefault.blurPx}
-              onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), blurPx: v } })}
-            />
-            <NumberField
-              label="Opacity"
-              min={0}
-              max={1}
-              step={0.05}
-              value={selectedInsert.shadow?.opacity ?? doc.insertShadowDefault.opacity}
-              onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), opacity: v } })}
-            />
-          </div>
-          <ColorField
-            label="Color"
-            value={selectedInsert.shadow?.color ?? doc.insertShadowDefault.color}
-            onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), color: v } })}
-          />
-
-          <button
-            onClick={() => {
-              editDoc((d) => ({ ...d, inserts: d.inserts.filter((i) => i.id !== selectedInsert.id) }))
-              selectInsert(null)
-            }}
-          >
-            Remove insert
-          </button>
-        </section>
-      )}
-
-      {doc.inserts.length > 0 && (
-        <section>
-          <h3>All inserts</h3>
-          <ul className="insert-list">
-            {doc.inserts.map((insert, idx) => (
-              <li key={insert.id}>
-                <button className={insert.id === selectedInsertId ? 'active' : ''} onClick={() => selectInsert(insert.id)}>
-                  Insert {idx + 1}
-                </button>
-              </li>
-            ))}
-          </ul>
         </section>
       )}
     </div>

--- a/src/collage-studio/components/InspectorPanel.tsx
+++ b/src/collage-studio/components/InspectorPanel.tsx
@@ -220,6 +220,7 @@ export function InspectorPanel() {
             <p className="hint">Drag an image from the library onto this frame, or click a thumbnail.</p>
           ) : (
             <>
+              <p className="hint">Drag the image to pan, scroll to zoom, or double-click to reset zoom/pan.</p>
               <NumberField
                 label="Zoom"
                 min={1}
@@ -282,7 +283,10 @@ export function InspectorPanel() {
               shadow override are still in the data model but not exposed
               here -- they follow the doc-level defaults (see the "Inserts
               (default border/shadow)" sections above). */}
-          <p className="hint">Drag the insert to pan its image, scroll to zoom, or use the move/resize handles.</p>
+          <p className="hint">
+            Drag the insert to pan its image, scroll to zoom, or use the move/resize handles. Double-click to reset
+            zoom/pan.
+          </p>
           <label className="field">
             <span>Corner radius (0 = square, 50 = circle)</span>
             <input

--- a/src/collage-studio/components/InspectorPanel.tsx
+++ b/src/collage-studio/components/InspectorPanel.tsx
@@ -1,5 +1,5 @@
 import { collectFrames } from '../model/geometry'
-import { DEFAULT_INSERT_SHADOW, MAX_ZOOM, type Insert } from '../model/collageTypes'
+import { MAX_ZOOM, type Insert } from '../model/collageTypes'
 import { updateFrame } from '../model/treeOps'
 import { useCollageStore } from '../state/collageStore'
 import { useImagePool } from '../state/imagePoolStore'
@@ -144,15 +144,7 @@ export function InspectorPanel() {
             onChange={(v) => editDoc((d) => ({ ...d, border: { ...d.border, grid: { ...d.border.grid, color: v } } }))}
           />
         </div>
-        <h4>Inserts (default)</h4>
-        <label className="field checkbox">
-          <input
-            type="checkbox"
-            checked={doc.insertBorderDefault.enabled}
-            onChange={(e) => editDoc((d) => ({ ...d, insertBorderDefault: { ...d.insertBorderDefault, enabled: e.target.checked } }))}
-          />
-          <span>Enabled</span>
-        </label>
+        <h4>Inserts (default border)</h4>
         <div className="field-row">
           <NumberField
             label="Width"
@@ -174,6 +166,52 @@ export function InspectorPanel() {
           }
         >
           Apply default border to all inserts
+        </button>
+
+        <h4>Inserts (default shadow)</h4>
+        <div className="field-row">
+          <NumberField
+            label="Size (offset px)"
+            min={0}
+            max={60}
+            step={1}
+            value={doc.insertShadowDefault.offsetPx}
+            onChange={(v) => editDoc((d) => ({ ...d, insertShadowDefault: { ...d.insertShadowDefault, offsetPx: v } }))}
+          />
+          <NumberField
+            label="Direction (deg)"
+            min={0}
+            max={360}
+            step={1}
+            value={doc.insertShadowDefault.angleDeg}
+            onChange={(v) => editDoc((d) => ({ ...d, insertShadowDefault: { ...d.insertShadowDefault, angleDeg: v } }))}
+          />
+        </div>
+        <div className="field-row">
+          <NumberField
+            label="Blur (px)"
+            min={0}
+            max={60}
+            step={1}
+            value={doc.insertShadowDefault.blurPx}
+            onChange={(v) => editDoc((d) => ({ ...d, insertShadowDefault: { ...d.insertShadowDefault, blurPx: v } }))}
+          />
+          <NumberField
+            label="Opacity"
+            min={0}
+            max={1}
+            step={0.05}
+            value={doc.insertShadowDefault.opacity}
+            onChange={(v) => editDoc((d) => ({ ...d, insertShadowDefault: { ...d.insertShadowDefault, opacity: v } }))}
+          />
+        </div>
+        <ColorField
+          label="Color"
+          value={doc.insertShadowDefault.color}
+          onChange={(v) => editDoc((d) => ({ ...d, insertShadowDefault: { ...d.insertShadowDefault, color: v } }))}
+        />
+        <button onClick={() => editDoc((d) => ({ ...d, inserts: d.inserts.map((i) => ({ ...i, shadow: null })) }))}>
+          Apply default shadow to all inserts
         </button>
       </section>
 
@@ -282,60 +320,56 @@ export function InspectorPanel() {
           <label className="field checkbox">
             <input
               type="checkbox"
-              checked={selectedInsert.shadow?.enabled ?? false}
+              checked={selectedInsert.shadow?.enabled ?? doc.insertShadowDefault.enabled}
               onChange={(e) =>
                 updateInsert(selectedInsert.id, {
-                  shadow: e.target.checked ? { ...(selectedInsert.shadow ?? DEFAULT_INSERT_SHADOW), enabled: true } : { ...(selectedInsert.shadow ?? DEFAULT_INSERT_SHADOW), enabled: false },
+                  shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), enabled: e.target.checked },
                 })
               }
             />
-            <span>Enabled</span>
+            <span>Override shadow (unchecked = use default)</span>
           </label>
-          {selectedInsert.shadow?.enabled && (
-            <>
-              <div className="field-row">
-                <NumberField
-                  label="Size (offset px)"
-                  min={0}
-                  max={60}
-                  step={1}
-                  value={selectedInsert.shadow.offsetPx}
-                  onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...selectedInsert.shadow!, offsetPx: v } })}
-                />
-                <NumberField
-                  label="Direction (deg)"
-                  min={0}
-                  max={360}
-                  step={1}
-                  value={selectedInsert.shadow.angleDeg}
-                  onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...selectedInsert.shadow!, angleDeg: v } })}
-                />
-              </div>
-              <div className="field-row">
-                <NumberField
-                  label="Blur (px)"
-                  min={0}
-                  max={60}
-                  step={1}
-                  value={selectedInsert.shadow.blurPx}
-                  onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...selectedInsert.shadow!, blurPx: v } })}
-                />
-                <NumberField
-                  label="Opacity"
-                  min={0}
-                  max={1}
-                  step={0.05}
-                  value={selectedInsert.shadow.opacity}
-                  onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...selectedInsert.shadow!, opacity: v } })}
-                />
-              </div>
-              <ColorField
-                label="Color"
-                value={selectedInsert.shadow.color}
-                onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...selectedInsert.shadow!, color: v } })}
-              />
-            </>
-          )}
+          <div className="field-row">
+            <NumberField
+              label="Size (offset px)"
+              min={0}
+              max={60}
+              step={1}
+              value={selectedInsert.shadow?.offsetPx ?? doc.insertShadowDefault.offsetPx}
+              onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), offsetPx: v } })}
+            />
+            <NumberField
+              label="Direction (deg)"
+              min={0}
+              max={360}
+              step={1}
+              value={selectedInsert.shadow?.angleDeg ?? doc.insertShadowDefault.angleDeg}
+              onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), angleDeg: v } })}
+            />
+          </div>
+          <div className="field-row">
+            <NumberField
+              label="Blur (px)"
+              min={0}
+              max={60}
+              step={1}
+              value={selectedInsert.shadow?.blurPx ?? doc.insertShadowDefault.blurPx}
+              onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), blurPx: v } })}
+            />
+            <NumberField
+              label="Opacity"
+              min={0}
+              max={1}
+              step={0.05}
+              value={selectedInsert.shadow?.opacity ?? doc.insertShadowDefault.opacity}
+              onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), opacity: v } })}
+            />
+          </div>
+          <ColorField
+            label="Color"
+            value={selectedInsert.shadow?.color ?? doc.insertShadowDefault.color}
+            onChange={(v) => updateInsert(selectedInsert.id, { shadow: { ...(selectedInsert.shadow ?? doc.insertShadowDefault), color: v } })}
+          />
 
           <button
             onClick={() => {

--- a/src/collage-studio/components/InspectorPanel.tsx
+++ b/src/collage-studio/components/InspectorPanel.tsx
@@ -273,14 +273,16 @@ export function InspectorPanel() {
       {selectedInsert && (
         <section>
           <h3>Selected insert</h3>
-          {/* Simplified to just corner radius, matching the new design --
-              size/zoom/feather/focal/border-override/shadow-override are
-              still in the data model (see model/collageTypes.ts) and still
-              apply (via doc-level defaults for border/shadow), just no
-              longer independently editable per-insert from this panel.
-              Move/resize now happens by removing and re-adding the insert
-              (the seam "+"/remove-X on the canvas) rather than drag/resize
-              handles -- see CanvasEditor.tsx. */}
+          {/* Simplified down from a full panel (still matching the new
+              design's intent), but not to *just* corner radius anymore --
+              size/zoom/focal are now direct-manipulation on the canvas
+              itself (resize/move handles, wheel-to-zoom, drag-to-pan; see
+              CanvasEditor.tsx), so they don't need fields here. Feather has
+              no canvas gesture equivalent, so it's kept as a field. Border/
+              shadow override are still in the data model but not exposed
+              here -- they follow the doc-level defaults (see the "Inserts
+              (default border/shadow)" sections above). */}
+          <p className="hint">Drag the insert to pan its image, scroll to zoom, or use the move/resize handles.</p>
           <label className="field">
             <span>Corner radius (0 = square, 50 = circle)</span>
             <input
@@ -298,6 +300,14 @@ export function InspectorPanel() {
               onChange={(e) => updateInsert(selectedInsert.id, { cornerRadiusPct: Number(e.target.value) / 100 })}
             />
           </label>
+          <NumberField
+            label="Feather (px)"
+            min={0}
+            max={60}
+            step={1}
+            value={selectedInsert.featherPx}
+            onChange={(v) => updateInsert(selectedInsert.id, { featherPx: v })}
+          />
         </section>
       )}
     </div>

--- a/src/collage-studio/components/LibraryPanel.tsx
+++ b/src/collage-studio/components/LibraryPanel.tsx
@@ -123,7 +123,7 @@ export function LibraryPanel() {
 
       {pool.images.length > 0 && (
         <div className="library-gallery-header">
-          <span className="hint">{pool.images.length} image(s)</span>
+          <span className="hint">{pool.images.length}</span>
           <div className="library-header-actions">
             <button className="library-add-btn" onClick={() => fileInputRef.current?.click()} title="Add photos">
               +
@@ -151,7 +151,7 @@ export function LibraryPanel() {
                   : `Removes ${unusedImages.length} image(s) not used by any open collage; images still in use are kept`
               }
             >
-              Clear gallery{unusedImages.length > 0 ? ` (${unusedImages.length})` : ''}
+              Clear{unusedImages.length > 0 ? ` (${unusedImages.length})` : ''}
             </button>
           </div>
         </div>

--- a/src/collage-studio/components/LibraryPanel.tsx
+++ b/src/collage-studio/components/LibraryPanel.tsx
@@ -33,12 +33,20 @@ export function LibraryPanel() {
     const el = thumbsRef.current
     if (!el) return
     // Native (non-passive) listener -- React's onWheel can't reliably
-    // preventDefault() to stop the page/panel from also scrolling.
+    // preventDefault(). Gated on Ctrl/Cmd so plain scrolling still scrolls
+    // the list -- an earlier version resized on *every* wheel tick, which
+    // meant there was no way left to scroll a long gallery with the wheel.
     const handler = (e: WheelEvent) => {
+      if (!e.ctrlKey && !e.metaKey) return
       e.preventDefault()
       const step = e.deltaY > 0 ? 1 : -1
       setColumns((c) => {
-        const current = c ?? Math.max(MIN_COLUMNS, Math.round(el.clientWidth / (THUMB_MIN_PX + THUMB_GAP_PX)))
+        // clientWidth is the content box (padding already excluded, and
+        // scrollbar-gutter keeps the scrollbar out of it too) -- subtract
+        // one gap-width's worth of slack per column so the seeded guess
+        // undershoots slightly rather than overshoots into invisible/
+        // under-scrollbar territory.
+        const current = c ?? Math.max(MIN_COLUMNS, Math.floor(el.clientWidth / (THUMB_MIN_PX + THUMB_GAP_PX)))
         return Math.max(MIN_COLUMNS, Math.min(MAX_COLUMNS, current + step))
       })
     }
@@ -96,71 +104,67 @@ export function LibraryPanel() {
   }
 
   return (
-    <div className="library-panel">
-      <div
-        className={`library-dropzone${isDragOver ? ' drag-over' : ''}`}
-        onDragOver={(e) => {
-          e.preventDefault()
-          setIsDragOver(true)
+    <div
+      className={`library-panel${isDragOver ? ' drag-over' : ''}`}
+      onDragOver={(e) => {
+        e.preventDefault()
+        setIsDragOver(true)
+      }}
+      onDragLeave={() => setIsDragOver(false)}
+      onDrop={onDrop}
+    >
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        hidden
+        onChange={(e) => {
+          if (e.target.files) void pool.add(e.target.files)
+          e.target.value = ''
         }}
-        onDragLeave={() => setIsDragOver(false)}
-        onDrop={onDrop}
-        onClick={() => fileInputRef.current?.click()}
-      >
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          multiple
-          hidden
-          onChange={(e) => {
-            if (e.target.files) void pool.add(e.target.files)
-            e.target.value = ''
-          }}
-        />
-        <span>Drop images here, or click to choose (from Explorer/Finder, or Gallery on mobile)</span>
+      />
+
+      <div className="library-gallery-header">
+        <span className="hint">{pool.images.length}</span>
+        <div className="library-header-actions">
+          <button className="library-add-btn" onClick={() => fileInputRef.current?.click()} title="Add photos">
+            +
+          </button>
+          <button
+            className={sortKey === 'name' ? 'active' : undefined}
+            onClick={() => toggleSort('name')}
+            title="Sort by name"
+          >
+            Name{sortKey === 'name' ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''}
+          </button>
+          <button
+            className={sortKey === 'date' ? 'active' : undefined}
+            onClick={() => toggleSort('date')}
+            title="Sort by date added"
+          >
+            Date{sortKey === 'date' ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''}
+          </button>
+          <button
+            onClick={handleClearGallery}
+            disabled={unusedImages.length === 0}
+            title={
+              unusedImages.length === 0
+                ? 'Every image here is used by an open collage -- nothing to remove'
+                : `Removes ${unusedImages.length} image(s) not used by any open collage; images still in use are kept`
+            }
+          >
+            Clear{unusedImages.length > 0 ? ` (${unusedImages.length})` : ''}
+          </button>
+        </div>
       </div>
 
-      {pool.images.length > 0 && (
-        <div className="library-gallery-header">
-          <span className="hint">{pool.images.length}</span>
-          <div className="library-header-actions">
-            <button className="library-add-btn" onClick={() => fileInputRef.current?.click()} title="Add photos">
-              +
-            </button>
-            <button
-              className={sortKey === 'name' ? 'active' : undefined}
-              onClick={() => toggleSort('name')}
-              title="Sort by name"
-            >
-              Name{sortKey === 'name' ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''}
-            </button>
-            <button
-              className={sortKey === 'date' ? 'active' : undefined}
-              onClick={() => toggleSort('date')}
-              title="Sort by date added"
-            >
-              Date{sortKey === 'date' ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''}
-            </button>
-            <button
-              onClick={handleClearGallery}
-              disabled={unusedImages.length === 0}
-              title={
-                unusedImages.length === 0
-                  ? 'Every image here is used by an open collage -- nothing to remove'
-                  : `Removes ${unusedImages.length} image(s) not used by any open collage; images still in use are kept`
-              }
-            >
-              Clear{unusedImages.length > 0 ? ` (${unusedImages.length})` : ''}
-            </button>
-          </div>
-        </div>
-      )}
+      {pool.images.length === 0 && <p className="library-thumbs-hint">Drop images anywhere here, or tap + to add.</p>}
 
       <div
         className="library-thumbs"
         ref={thumbsRef}
-        title="Scroll here to resize thumbnails"
+        title="Ctrl+Scroll (Cmd+Scroll on Mac) to resize thumbnails"
         style={columns ? { gridTemplateColumns: `repeat(${columns}, 1fr)` } : undefined}
       >
         {sortedImages.map((img) => (

--- a/src/collage-studio/components/LibraryPanel.tsx
+++ b/src/collage-studio/components/LibraryPanel.tsx
@@ -1,22 +1,29 @@
 import { useRef, useState } from 'react'
+import { collectImageKeys } from '../model/geometry'
 import { setFrameImage } from '../model/treeOps'
 import { useCollageStore } from '../state/collageStore'
 import { useDialog } from '../state/dialogStore'
 import { useImagePool } from '../state/imagePoolStore'
 
 export function LibraryPanel() {
-  const { doc, editDoc, selectedFrameId, selectedInsertId } = useCollageStore()
+  const { doc, editDoc, selectedFrameId, selectedInsertId, allDocs } = useCollageStore()
   const pool = useImagePool()
   const dialog = useDialog()
   const [isDragOver, setIsDragOver] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
+  // Only removes images no *open* collage references -- anything still in
+  // use (even in a background tab) is kept, so this can't silently break a
+  // collage you haven't looked at recently.
   const handleClearGallery = async () => {
-    if (pool.images.length === 0) return
+    const usedKeys = new Set(allDocs.flatMap(collectImageKeys))
+    const unused = pool.images.filter((img) => !usedKeys.has(img.key))
+    if (unused.length === 0) return
+    const keptCount = pool.images.length - unused.length
     const ok = await dialog.confirm(
-      `Remove all ${pool.images.length} image(s) from your local gallery? This can't be undone -- any collage still referencing them will show "missing image" until you re-add them.`,
+      `Remove ${unused.length} unused image(s) from your local gallery? ${keptCount} still in use by open collages will be kept. This can't be undone.`,
     )
-    if (ok) await pool.clearAll()
+    if (ok) await pool.removeMany(unused.map((img) => img.key))
   }
 
   // Assigns to whichever is currently selected -- a frame or an insert (its
@@ -66,7 +73,9 @@ export function LibraryPanel() {
       {pool.images.length > 0 && (
         <div className="library-gallery-header">
           <span className="hint">{pool.images.length} image(s)</span>
-          <button onClick={handleClearGallery}>Clear gallery</button>
+          <button onClick={handleClearGallery} title="Removes images not used by any open collage; images still in use are kept">
+            Clear gallery
+          </button>
         </div>
       )}
 

--- a/src/collage-studio/components/LibraryPanel.tsx
+++ b/src/collage-studio/components/LibraryPanel.tsx
@@ -5,12 +5,32 @@ import { useCollageStore } from '../state/collageStore'
 import { useDialog } from '../state/dialogStore'
 import { useImagePool } from '../state/imagePoolStore'
 
+type SortKey = 'name' | 'date'
+type SortDir = 'asc' | 'desc'
+
 export function LibraryPanel() {
   const { doc, editDoc, selectedFrameId, selectedInsertId, allDocs } = useCollageStore()
   const pool = useImagePool()
   const dialog = useDialog()
   const [isDragOver, setIsDragOver] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  // Date/desc (newest first) matches the pool's own default ordering.
+  const [sortKey, setSortKey] = useState<SortKey>('date')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+
+  const toggleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      setSortDir(key === 'name' ? 'asc' : 'desc')
+    }
+  }
+
+  const sortedImages = [...pool.images].sort((a, b) => {
+    const cmp = sortKey === 'name' ? a.name.localeCompare(b.name) : a.addedAt - b.addedAt
+    return sortDir === 'asc' ? cmp : -cmp
+  })
 
   // Only removes images no *open* collage references -- anything still in
   // use (even in a background tab) is kept, so this can't silently break a
@@ -76,45 +96,72 @@ export function LibraryPanel() {
       {pool.images.length > 0 && (
         <div className="library-gallery-header">
           <span className="hint">{pool.images.length} image(s)</span>
-          <button
-            onClick={handleClearGallery}
-            disabled={unusedImages.length === 0}
-            title={
-              unusedImages.length === 0
-                ? 'Every image here is used by an open collage -- nothing to remove'
-                : `Removes ${unusedImages.length} image(s) not used by any open collage; images still in use are kept`
-            }
-          >
-            Clear gallery{unusedImages.length > 0 ? ` (${unusedImages.length})` : ''}
-          </button>
+          <div className="library-header-actions">
+            <button className="library-add-btn" onClick={() => fileInputRef.current?.click()} title="Add photos">
+              +
+            </button>
+            <button
+              className={sortKey === 'name' ? 'active' : undefined}
+              onClick={() => toggleSort('name')}
+              title="Sort by name"
+            >
+              Name{sortKey === 'name' ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''}
+            </button>
+            <button
+              className={sortKey === 'date' ? 'active' : undefined}
+              onClick={() => toggleSort('date')}
+              title="Sort by date added"
+            >
+              Date{sortKey === 'date' ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''}
+            </button>
+            <button
+              onClick={handleClearGallery}
+              disabled={unusedImages.length === 0}
+              title={
+                unusedImages.length === 0
+                  ? 'Every image here is used by an open collage -- nothing to remove'
+                  : `Removes ${unusedImages.length} image(s) not used by any open collage; images still in use are kept`
+              }
+            >
+              Clear gallery{unusedImages.length > 0 ? ` (${unusedImages.length})` : ''}
+            </button>
+          </div>
         </div>
       )}
 
       <div className="library-thumbs">
-        {pool.images.map((img) => (
-          <div key={img.key} className="library-thumb-wrap">
-            <img
-              src={img.objectUrl}
-              alt={img.name}
-              title={
-                selectedInsertId
-                  ? `${img.name} (click to assign to selected insert)`
-                  : selectedFrameId
-                    ? `${img.name} (click to assign to selected frame)`
-                    : img.name
-              }
-              draggable
-              className="library-thumb"
-              onDragStart={(e) => e.dataTransfer.setData('application/x-collage-image', img.key)}
-              onClick={() => assignToSelected(img.key)}
-              onDoubleClick={() => assignToSelected(img.key)}
-            />
-            <button className="library-thumb-remove" title="Remove from gallery" onClick={() => pool.remove(img.key)}>
+        {sortedImages.map((img) => (
+          <div
+            key={img.key}
+            className="library-thumb-wrap"
+            draggable
+            title={
+              selectedInsertId
+                ? `${img.name} (click to assign to selected insert)`
+                : selectedFrameId
+                  ? `${img.name} (click to assign to selected frame)`
+                  : img.name
+            }
+            onDragStart={(e) => e.dataTransfer.setData('application/x-collage-image', img.key)}
+            onClick={() => assignToSelected(img.key)}
+            onDoubleClick={() => assignToSelected(img.key)}
+          >
+            <img src={img.objectUrl} alt={img.name} className="library-thumb" />
+            <span className="library-thumb-name">{img.name}</span>
+            <button
+              className="library-thumb-remove"
+              title="Remove from gallery"
+              onClick={(e) => {
+                e.stopPropagation()
+                pool.remove(img.key)
+              }}
+            >
               ✕
             </button>
           </div>
         ))}
       </div>
+      <p className="library-thumbs-hint">Drag an image directly onto a frame in the canvas to place it there.</p>
     </div>
   )
 }

--- a/src/collage-studio/components/LibraryPanel.tsx
+++ b/src/collage-studio/components/LibraryPanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { collectImageKeys } from '../model/geometry'
 import { setFrameImage } from '../model/treeOps'
 import { useCollageStore } from '../state/collageStore'
@@ -7,6 +7,11 @@ import { useImagePool } from '../state/imagePoolStore'
 
 type SortKey = 'name' | 'date'
 type SortDir = 'asc' | 'desc'
+
+const THUMB_MIN_PX = 104
+const THUMB_GAP_PX = 10
+const MIN_COLUMNS = 1
+const MAX_COLUMNS = 10
 
 export function LibraryPanel() {
   const { doc, editDoc, selectedFrameId, selectedInsertId, allDocs } = useCollageStore()
@@ -17,6 +22,29 @@ export function LibraryPanel() {
   // Date/desc (newest first) matches the pool's own default ordering.
   const [sortKey, setSortKey] = useState<SortKey>('date')
   const [sortDir, setSortDir] = useState<SortDir>('desc')
+
+  // Thumbnail grid density -- null means "auto" (the CSS auto-fill default,
+  // ~104px minimum). Scrolling over the grid switches to an explicit
+  // columns-per-row count, stepping from whatever's currently on screen.
+  const [columns, setColumns] = useState<number | null>(null)
+  const thumbsRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = thumbsRef.current
+    if (!el) return
+    // Native (non-passive) listener -- React's onWheel can't reliably
+    // preventDefault() to stop the page/panel from also scrolling.
+    const handler = (e: WheelEvent) => {
+      e.preventDefault()
+      const step = e.deltaY > 0 ? 1 : -1
+      setColumns((c) => {
+        const current = c ?? Math.max(MIN_COLUMNS, Math.round(el.clientWidth / (THUMB_MIN_PX + THUMB_GAP_PX)))
+        return Math.max(MIN_COLUMNS, Math.min(MAX_COLUMNS, current + step))
+      })
+    }
+    el.addEventListener('wheel', handler, { passive: false })
+    return () => el.removeEventListener('wheel', handler)
+  }, [])
 
   const toggleSort = (key: SortKey) => {
     if (sortKey === key) {
@@ -129,7 +157,12 @@ export function LibraryPanel() {
         </div>
       )}
 
-      <div className="library-thumbs">
+      <div
+        className="library-thumbs"
+        ref={thumbsRef}
+        title="Scroll here to resize thumbnails"
+        style={columns ? { gridTemplateColumns: `repeat(${columns}, 1fr)` } : undefined}
+      >
         {sortedImages.map((img) => (
           <div
             key={img.key}

--- a/src/collage-studio/components/LibraryPanel.tsx
+++ b/src/collage-studio/components/LibraryPanel.tsx
@@ -29,6 +29,35 @@ export function LibraryPanel() {
   const [columns, setColumns] = useState<number | null>(null)
   const thumbsRef = useRef<HTMLDivElement>(null)
 
+  // A fixed column count is deliberately decoupled from the panel's own
+  // width (so pinch/Ctrl+Scroll steps predictably), but that means it
+  // doesn't shrink/grow along with the panel either once set -- dragging
+  // the library-panel resize handle would otherwise stop visibly resizing
+  // thumbnails at all until the next manual pinch/scroll. Revert to "auto"
+  // whenever the panel itself is resized (not by a column-count change --
+  // that never alters the grid's own width, only how a fixed width is
+  // divided -- so this only fires on real panel resizes).
+  useEffect(() => {
+    const el = thumbsRef.current
+    if (!el) return
+    let seeded = false
+    let lastWidth = 0
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0].contentRect.width
+      if (!seeded) {
+        seeded = true
+        lastWidth = w
+        return
+      }
+      if (Math.abs(w - lastWidth) > 0.5) {
+        lastWidth = w
+        setColumns(null)
+      }
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
   useEffect(() => {
     const el = thumbsRef.current
     if (!el) return

--- a/src/collage-studio/components/LibraryPanel.tsx
+++ b/src/collage-studio/components/LibraryPanel.tsx
@@ -14,16 +14,19 @@ export function LibraryPanel() {
 
   // Only removes images no *open* collage references -- anything still in
   // use (even in a background tab) is kept, so this can't silently break a
-  // collage you haven't looked at recently.
+  // collage you haven't looked at recently. Computed at render time (not
+  // just inside the click handler) so the button can show/disable based on
+  // whether there's actually anything to remove.
+  const usedKeys = new Set(allDocs.flatMap(collectImageKeys))
+  const unusedImages = pool.images.filter((img) => !usedKeys.has(img.key))
+
   const handleClearGallery = async () => {
-    const usedKeys = new Set(allDocs.flatMap(collectImageKeys))
-    const unused = pool.images.filter((img) => !usedKeys.has(img.key))
-    if (unused.length === 0) return
-    const keptCount = pool.images.length - unused.length
+    if (unusedImages.length === 0) return
+    const keptCount = pool.images.length - unusedImages.length
     const ok = await dialog.confirm(
-      `Remove ${unused.length} unused image(s) from your local gallery? ${keptCount} still in use by open collages will be kept. This can't be undone.`,
+      `Remove ${unusedImages.length} unused image(s) from your local gallery? ${keptCount} still in use by open collages will be kept. This can't be undone.`,
     )
-    if (ok) await pool.removeMany(unused.map((img) => img.key))
+    if (ok) await pool.removeMany(unusedImages.map((img) => img.key))
   }
 
   // Assigns to whichever is currently selected -- a frame or an insert (its
@@ -73,8 +76,16 @@ export function LibraryPanel() {
       {pool.images.length > 0 && (
         <div className="library-gallery-header">
           <span className="hint">{pool.images.length} image(s)</span>
-          <button onClick={handleClearGallery} title="Removes images not used by any open collage; images still in use are kept">
-            Clear gallery
+          <button
+            onClick={handleClearGallery}
+            disabled={unusedImages.length === 0}
+            title={
+              unusedImages.length === 0
+                ? 'Every image here is used by an open collage -- nothing to remove'
+                : `Removes ${unusedImages.length} image(s) not used by any open collage; images still in use are kept`
+            }
+          >
+            Clear gallery{unusedImages.length > 0 ? ` (${unusedImages.length})` : ''}
           </button>
         </div>
       )}

--- a/src/collage-studio/components/LibraryPanel.tsx
+++ b/src/collage-studio/components/LibraryPanel.tsx
@@ -32,14 +32,8 @@ export function LibraryPanel() {
   useEffect(() => {
     const el = thumbsRef.current
     if (!el) return
-    // Native (non-passive) listener -- React's onWheel can't reliably
-    // preventDefault(). Gated on Ctrl/Cmd so plain scrolling still scrolls
-    // the list -- an earlier version resized on *every* wheel tick, which
-    // meant there was no way left to scroll a long gallery with the wheel.
-    const handler = (e: WheelEvent) => {
-      if (!e.ctrlKey && !e.metaKey) return
-      e.preventDefault()
-      const step = e.deltaY > 0 ? 1 : -1
+
+    const stepColumns = (step: number) => {
       setColumns((c) => {
         // clientWidth is the content box (padding already excluded, and
         // scrollbar-gutter keeps the scrollbar out of it too) -- subtract
@@ -50,8 +44,61 @@ export function LibraryPanel() {
         return Math.max(MIN_COLUMNS, Math.min(MAX_COLUMNS, current + step))
       })
     }
-    el.addEventListener('wheel', handler, { passive: false })
-    return () => el.removeEventListener('wheel', handler)
+
+    // Native (non-passive) listener -- React's onWheel can't reliably
+    // preventDefault(). Gated on Ctrl/Cmd so plain scrolling still scrolls
+    // the list -- an earlier version resized on *every* wheel tick, which
+    // meant there was no way left to scroll a long gallery with the wheel.
+    const onWheel = (e: WheelEvent) => {
+      if (!e.ctrlKey && !e.metaKey) return
+      e.preventDefault()
+      stepColumns(e.deltaY > 0 ? 1 : -1)
+    }
+
+    // Pinch-to-resize on touch -- same column-stepping as Ctrl+Scroll, just
+    // driven by two-finger pinch distance instead. Distance change is
+    // accumulated and only converted into a step every PINCH_STEP_PX of
+    // travel, so it steps discretely rather than firing on every touchmove.
+    const PINCH_STEP_PX = 40
+    let pinchDist: number | null = null
+    let pinchAccum = 0
+    const touchDist = (touches: TouchList) => Math.hypot(touches[0].clientX - touches[1].clientX, touches[0].clientY - touches[1].clientY)
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (e.touches.length === 2) {
+        pinchDist = touchDist(e.touches)
+        pinchAccum = 0
+      }
+    }
+    const onTouchMove = (e: TouchEvent) => {
+      if (e.touches.length !== 2 || pinchDist === null) return
+      e.preventDefault()
+      const dist = touchDist(e.touches)
+      pinchAccum += dist - pinchDist
+      pinchDist = dist
+      while (Math.abs(pinchAccum) >= PINCH_STEP_PX) {
+        // Pinching outward (fingers spreading, distance growing) means
+        // "bigger thumbnails" -- fewer columns.
+        stepColumns(pinchAccum > 0 ? -1 : 1)
+        pinchAccum += pinchAccum > 0 ? -PINCH_STEP_PX : PINCH_STEP_PX
+      }
+    }
+    const onTouchEnd = (e: TouchEvent) => {
+      if (e.touches.length < 2) pinchDist = null
+    }
+
+    el.addEventListener('wheel', onWheel, { passive: false })
+    el.addEventListener('touchstart', onTouchStart, { passive: true })
+    el.addEventListener('touchmove', onTouchMove, { passive: false })
+    el.addEventListener('touchend', onTouchEnd)
+    el.addEventListener('touchcancel', onTouchEnd)
+    return () => {
+      el.removeEventListener('wheel', onWheel)
+      el.removeEventListener('touchstart', onTouchStart)
+      el.removeEventListener('touchmove', onTouchMove)
+      el.removeEventListener('touchend', onTouchEnd)
+      el.removeEventListener('touchcancel', onTouchEnd)
+    }
   }, [])
 
   const toggleSort = (key: SortKey) => {
@@ -164,7 +211,7 @@ export function LibraryPanel() {
       <div
         className="library-thumbs"
         ref={thumbsRef}
-        title="Ctrl+Scroll (Cmd+Scroll on Mac) to resize thumbnails"
+        title="Ctrl+Scroll (Cmd+Scroll on Mac), or pinch on touch, to resize thumbnails"
         style={columns ? { gridTemplateColumns: `repeat(${columns}, 1fr)` } : undefined}
       >
         {sortedImages.map((img) => (

--- a/src/collage-studio/components/Toolbar.tsx
+++ b/src/collage-studio/components/Toolbar.tsx
@@ -10,8 +10,28 @@ import { useImagePool } from '../state/imagePoolStore'
 interface ToolbarProps {
   previewMode: boolean
   onTogglePreview: () => void
+  mobileLibraryOpen: boolean
   onToggleLibrary: () => void
+  mobileInspectorOpen: boolean
   onToggleInspector: () => void
+}
+
+function LibraryPanelIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16">
+      <rect x="1.5" y="2.5" width="13" height="11" rx="1.5" fill="none" stroke="currentColor" strokeWidth="1.3" />
+      <rect x="1.5" y="2.5" width="5" height="11" rx="1.5" fill="currentColor" opacity="0.55" />
+    </svg>
+  )
+}
+
+function InspectorPanelIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16">
+      <rect x="1.5" y="2.5" width="13" height="11" rx="1.5" fill="none" stroke="currentColor" strokeWidth="1.3" />
+      <rect x="9.5" y="2.5" width="5" height="11" rx="1.5" fill="currentColor" opacity="0.55" />
+    </svg>
+  )
 }
 
 function sanitizeFilename(name: string): string {
@@ -35,7 +55,14 @@ function downloadBlob(blob: Blob, filename: string) {
   URL.revokeObjectURL(url)
 }
 
-export function Toolbar({ previewMode, onTogglePreview, onToggleLibrary, onToggleInspector }: ToolbarProps) {
+export function Toolbar({
+  previewMode,
+  onTogglePreview,
+  mobileLibraryOpen,
+  onToggleLibrary,
+  mobileInspectorOpen,
+  onToggleInspector,
+}: ToolbarProps) {
   const { doc, tabs, activeId, newDoc, openDoc, closeDoc, setActive, renameDoc, undo, redo, canUndo, canRedo, markSaved } = useCollageStore()
   const dialog = useDialog()
   const pool = useImagePool()
@@ -160,9 +187,6 @@ export function Toolbar({ previewMode, onTogglePreview, onToggleLibrary, onToggl
   return (
     <div className="toolbar-wrap">
       <div className="toolbar">
-        <button className="mobile-panel-toggle" onClick={onToggleLibrary} title="Show image library">
-          ☰ Library
-        </button>
         <div className="new-menu-wrap" ref={newMenuRef}>
           <button className="new-menu-main" onClick={handleNew}>
             New
@@ -216,14 +240,19 @@ export function Toolbar({ previewMode, onTogglePreview, onToggleLibrary, onToggl
         <button className={previewMode ? 'active' : undefined} onClick={onTogglePreview}>
           {previewMode ? 'Exit Preview' : 'Preview'}
         </button>
-        <button className="mobile-panel-toggle" onClick={onToggleInspector} title="Show adjustments panel">
-          Inspector ☰
-        </button>
         {status && <span className="toolbar-status">{status}</span>}
       </div>
 
       {tabs.length > 0 && (
         <div className="tabs-bar">
+          <button
+            className={`mobile-panel-icon-toggle${mobileLibraryOpen ? ' active' : ''}`}
+            onClick={onToggleLibrary}
+            title="Toggle Library"
+          >
+            <LibraryPanelIcon />
+          </button>
+          <div className="tabs-bar-tabs">
           {tabs.map((tab) => (
             <div key={tab.id} className={`tab${tab.id === activeId ? ' active' : ''}`} onClick={() => setActive(tab.id)}>
               {renamingTabId === tab.id ? (
@@ -265,6 +294,14 @@ export function Toolbar({ previewMode, onTogglePreview, onToggleLibrary, onToggl
               </button>
             </div>
           ))}
+          </div>
+          <button
+            className={`mobile-panel-icon-toggle${mobileInspectorOpen ? ' active' : ''}`}
+            onClick={onToggleInspector}
+            title="Toggle Inspector"
+          >
+            <InspectorPanelIcon />
+          </button>
         </div>
       )}
     </div>

--- a/src/collage-studio/components/Toolbar.tsx
+++ b/src/collage-studio/components/Toolbar.tsx
@@ -1,7 +1,8 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { api } from '../api/client'
 import { createBlankCollageDoc, type CollageDoc } from '../model/collageTypes'
 import { collectImageKeys } from '../model/geometry'
+import { LAYOUT_TEMPLATES } from '../model/templates'
 import { useCollageStore } from '../state/collageStore'
 import { useDialog } from '../state/dialogStore'
 import { useImagePool } from '../state/imagePoolStore'
@@ -42,6 +43,17 @@ export function Toolbar({ previewMode, onTogglePreview, onToggleLibrary, onToggl
   const openInputRef = useRef<HTMLInputElement>(null)
   const [renamingTabId, setRenamingTabId] = useState<string | null>(null)
   const [renameValue, setRenameValue] = useState('')
+  const [newMenuOpen, setNewMenuOpen] = useState(false)
+  const newMenuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!newMenuOpen) return
+    const onPointerDown = (e: PointerEvent) => {
+      if (newMenuRef.current && !newMenuRef.current.contains(e.target as Node)) setNewMenuOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [newMenuOpen])
 
   const startRename = (tabId: string, currentName: string) => {
     setRenamingTabId(tabId)
@@ -63,6 +75,13 @@ export function Toolbar({ previewMode, onTogglePreview, onToggleLibrary, onToggl
 
   const handleNew = () => {
     newDoc(createBlankCollageDoc())
+    setNewMenuOpen(false)
+  }
+
+  const handleNewFromTemplate = (build: () => CollageDoc['tree']) => {
+    const blank = createBlankCollageDoc()
+    newDoc({ ...blank, tree: build() })
+    setNewMenuOpen(false)
   }
 
   const handleOpenClick = () => openInputRef.current?.click()
@@ -144,7 +163,28 @@ export function Toolbar({ previewMode, onTogglePreview, onToggleLibrary, onToggl
         <button className="mobile-panel-toggle" onClick={onToggleLibrary} title="Show image library">
           ☰ Library
         </button>
-        <button onClick={handleNew}>New</button>
+        <div className="new-menu-wrap" ref={newMenuRef}>
+          <button className="new-menu-main" onClick={handleNew}>
+            New
+          </button>
+          <button className="new-menu-caret" onClick={() => setNewMenuOpen((o) => !o)} title="Choose a starting layout">
+            ▾
+          </button>
+          {newMenuOpen && (
+            <div className="new-menu-dropdown">
+              <button onClick={handleNew}>
+                <span className="layout-icon" />
+                Blank
+              </button>
+              {LAYOUT_TEMPLATES.map((t) => (
+                <button key={t.key} onClick={() => handleNewFromTemplate(t.build)}>
+                  <span className={`layout-icon layout-icon-${t.key}`} />
+                  {t.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
         <button onClick={handleOpenClick} title="Select the .collage.json and its images together to load both at once">
           Open…
         </button>

--- a/src/collage-studio/components/Toolbar.tsx
+++ b/src/collage-studio/components/Toolbar.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react'
 import { api } from '../api/client'
 import { createBlankCollageDoc, type CollageDoc } from '../model/collageTypes'
-import { collectFrames } from '../model/geometry'
+import { collectImageKeys } from '../model/geometry'
 import { useCollageStore } from '../state/collageStore'
 import { useDialog } from '../state/dialogStore'
 import { useImagePool } from '../state/imagePoolStore'
@@ -34,22 +34,8 @@ function downloadBlob(blob: Blob, filename: string) {
   URL.revokeObjectURL(url)
 }
 
-function collectImageKeys(doc: CollageDoc): string[] {
-  const frames = collectFrames(doc.tree)
-  const keys = new Set<string>()
-  for (const frame of Object.values(frames)) {
-    if (frame.image) keys.add(frame.image.imageKey)
-  }
-  // Inserts have their own, independent image assignment (see collageTypes.ts) --
-  // not necessarily used by any frame, so must be collected separately.
-  for (const insert of doc.inserts) {
-    if (insert.imageKey) keys.add(insert.imageKey)
-  }
-  return Array.from(keys)
-}
-
 export function Toolbar({ previewMode, onTogglePreview, onToggleLibrary, onToggleInspector }: ToolbarProps) {
-  const { doc, dirty, tabs, activeId, newDoc, openDoc, closeDoc, setActive, renameDoc, undo, redo, canUndo, canRedo, markSaved } = useCollageStore()
+  const { doc, tabs, activeId, newDoc, openDoc, closeDoc, setActive, renameDoc, undo, redo, canUndo, canRedo, markSaved } = useCollageStore()
   const dialog = useDialog()
   const pool = useImagePool()
   const [status, setStatus] = useState<string | null>(null)
@@ -174,7 +160,7 @@ export function Toolbar({ previewMode, onTogglePreview, onToggleLibrary, onToggl
           }}
         />
         <button disabled={!doc} onClick={handleExportLayout}>
-          Export{dirty ? ' *' : ''}
+          Export
         </button>
         <span className="toolbar-sep" />
         <button disabled={!canUndo} onClick={undo}>
@@ -202,6 +188,7 @@ export function Toolbar({ previewMode, onTogglePreview, onToggleLibrary, onToggl
             <div key={tab.id} className={`tab${tab.id === activeId ? ' active' : ''}`} onClick={() => setActive(tab.id)}>
               {renamingTabId === tab.id ? (
                 <input
+                  type="text"
                   className="tab-rename-input"
                   value={renameValue}
                   autoFocus

--- a/src/collage-studio/model/collageTypes.ts
+++ b/src/collage-studio/model/collageTypes.ts
@@ -102,6 +102,7 @@ export interface CollageDoc {
   border: BorderConfig
   jpegQuality: number
   insertBorderDefault: InsertBorder
+  insertShadowDefault: InsertShadow
   tree: Node
   inserts: Insert[]
 }
@@ -141,7 +142,10 @@ export function createBlankCollageDoc(name = 'Untitled collage'): CollageDoc {
       grid: { width: 8, color: '#000000' },
     },
     jpegQuality: 92,
-    insertBorderDefault: { enabled: false, width: 6, color: '#ffffff' },
+    // Insert defaults are always "enabled" -- no on/off toggle in the UI for
+    // these, width/opacity of 0 is how you'd effectively turn one off.
+    insertBorderDefault: { enabled: true, width: 6, color: '#ffffff' },
+    insertShadowDefault: { ...DEFAULT_INSERT_SHADOW },
     tree: makeFrame(),
     inserts: [],
   }

--- a/src/collage-studio/model/collageTypes.ts
+++ b/src/collage-studio/model/collageTypes.ts
@@ -118,6 +118,25 @@ export const DEFAULT_INSERT_SHADOW: InsertShadow = {
   color: '#000000',
 }
 
+export const DEFAULT_INSERT_BORDER: InsertBorder = {
+  enabled: true,
+  width: 6,
+  color: '#ffffff',
+}
+
+/** Backfills fields added after this doc might have been created/persisted
+ * (IndexedDB-hydrated docs, or an older exported .collage.json) so the rest
+ * of the app can assume every CollageDoc is complete. Without this, a doc
+ * missing e.g. insertShadowDefault crashes on the first `.enabled` read --
+ * and with no error boundary, that's a blank white screen, not a nice error. */
+export function normalizeDoc(doc: CollageDoc): CollageDoc {
+  return {
+    ...doc,
+    insertBorderDefault: doc.insertBorderDefault ?? { ...DEFAULT_INSERT_BORDER },
+    insertShadowDefault: doc.insertShadowDefault ?? { ...DEFAULT_INSERT_SHADOW },
+  }
+}
+
 let idCounter = 0
 export function newId(): string {
   idCounter += 1

--- a/src/collage-studio/model/collageTypes.ts
+++ b/src/collage-studio/model/collageTypes.ts
@@ -107,7 +107,11 @@ export interface CollageDoc {
   inserts: Insert[]
 }
 
-export const MAX_ZOOM = 1 / 0.3
+// Effectively "unlimited" for editing purposes while still keeping the crop
+// window from collapsing to a near-zero-pixel box (which would misbehave in
+// both the canvas preview and the Pillow render). Mirrored in
+// collage-studio-backend/app/models.py + render_engine.py -- keep in sync.
+export const MAX_ZOOM = 1 / 0.02
 
 export const DEFAULT_INSERT_SHADOW: InsertShadow = {
   enabled: true,

--- a/src/collage-studio/model/geometry.ts
+++ b/src/collage-studio/model/geometry.ts
@@ -3,7 +3,7 @@
 // constants -- so the live canvas preview never diverges from the Pillow
 // export.
 
-import { MAX_ZOOM, type FocalPoint, type FrameNode, type Node } from './collageTypes'
+import { MAX_ZOOM, type CollageDoc, type FocalPoint, type FrameNode, type Node } from './collageTypes'
 
 export type Rect = { x: number; y: number; w: number; h: number }
 
@@ -75,6 +75,20 @@ export function collectFrames(node: Node, out: Record<string, FrameNode> = {}): 
     collectFrames(node.second, out)
   }
   return out
+}
+
+/** Every imageKey a doc references, across both frames and inserts (inserts
+ * have their own independent image assignment -- see collageTypes.ts). */
+export function collectImageKeys(doc: CollageDoc): string[] {
+  const frames = collectFrames(doc.tree)
+  const keys = new Set<string>()
+  for (const frame of Object.values(frames)) {
+    if (frame.image) keys.add(frame.image.imageKey)
+  }
+  for (const insert of doc.inserts) {
+    if (insert.imageKey) keys.add(insert.imageKey)
+  }
+  return Array.from(keys)
 }
 
 /** Returns null if the two rects aren't geometrically adjacent (within gutter tolerance). */

--- a/src/collage-studio/model/templates.ts
+++ b/src/collage-studio/model/templates.ts
@@ -1,6 +1,8 @@
-import { makeFrame, newId, type Node, type SplitNode } from '../model/collageTypes'
-import { countFrames } from '../model/treeOps'
-import { useCollageStore } from '../state/collageStore'
+import { makeFrame, newId, type Node, type SplitNode } from './collageTypes'
+
+// Starting-point layouts, built from the same split primitive as manual
+// editing -- not a separate template system. Used by the Toolbar's "New ▾"
+// dropdown menu.
 
 function split(orientation: 'horizontal' | 'vertical', first: Node, second: Node, ratio = 0.5): SplitNode {
   return { type: 'split', id: newId(), orientation, ratio, first, second }
@@ -24,37 +26,20 @@ function evenGrid(cols: number, rows: number): Node {
   return buildCols(cols)
 }
 
-const TEMPLATES: { label: string; build: () => Node }[] = [
-  { label: '2 columns', build: () => split('horizontal', makeFrame(), makeFrame()) },
-  { label: '2 rows', build: () => split('vertical', makeFrame(), makeFrame()) },
+export const LAYOUT_TEMPLATES: { key: string; label: string; build: () => Node }[] = [
+  { key: 'twoCol', label: '2 columns', build: () => split('horizontal', makeFrame(), makeFrame()) },
+  { key: 'twoRow', label: '2 rows', build: () => split('vertical', makeFrame(), makeFrame()) },
   {
+    key: 'threeCol',
     label: '3 columns',
     build: () => split('horizontal', makeFrame(), split('horizontal', makeFrame(), makeFrame(), 0.5), 0.333),
   },
   {
+    key: 'twoXTwo',
     label: '2x2 grid',
     build: () =>
       split('vertical', split('horizontal', makeFrame(), makeFrame()), split('horizontal', makeFrame(), makeFrame())),
   },
-  { label: '3x3 grid', build: () => evenGrid(3, 3) },
-  { label: '4x4 grid', build: () => evenGrid(4, 4) },
+  { key: 'threeXThree', label: '3x3 grid', build: () => evenGrid(3, 3) },
+  { key: 'fourXFour', label: '4x4 grid', build: () => evenGrid(4, 4) },
 ]
-
-/** Starting-point layouts, built from the same split primitive as manual editing --
- * not a separate template system. Only offered while the canvas is still a single
- * blank frame, so it can't clobber in-progress work. */
-export function QuickStartTemplates() {
-  const { doc, editDoc } = useCollageStore()
-  if (!doc || countFrames(doc.tree) > 1) return null
-
-  return (
-    <div className="quick-start">
-      <span>Start from:</span>
-      {TEMPLATES.map((t) => (
-        <button key={t.label} onClick={() => editDoc((d) => ({ ...d, tree: t.build() }))}>
-          {t.label}
-        </button>
-      ))}
-    </div>
-  )
-}

--- a/src/collage-studio/state/collageStore.tsx
+++ b/src/collage-studio/state/collageStore.tsx
@@ -173,6 +173,9 @@ interface StoreApi {
   closeDoc: (id: string) => void
   setActive: (id: string) => void
   renameDoc: (id: string, name: string) => void
+  /** Every open collage's doc, across all tabs (not just the active one) --
+   * e.g. for "which images does any open collage still reference." */
+  allDocs: CollageDoc[]
 }
 
 const CollageStoreContext = createContext<StoreApi | null>(null)
@@ -257,6 +260,8 @@ export function CollageStoreProvider({ children }: { children: ReactNode }) {
     [state.order, state.entries],
   )
 
+  const allDocs = useMemo<CollageDoc[]>(() => state.order.map((id) => state.entries[id].doc), [state.order, state.entries])
+
   const value = useMemo<StoreApi>(
     () => ({
       doc: activeEntry?.doc ?? null,
@@ -278,8 +283,9 @@ export function CollageStoreProvider({ children }: { children: ReactNode }) {
       closeDoc,
       setActive,
       renameDoc,
+      allDocs,
     }),
-    [activeEntry, editDoc, undo, redo, selectFrame, selectInsert, markSaved, tabs, state.activeId, newDoc, openDoc, closeDoc, setActive, renameDoc],
+    [activeEntry, editDoc, undo, redo, selectFrame, selectInsert, markSaved, tabs, state.activeId, newDoc, openDoc, closeDoc, setActive, renameDoc, allDocs],
   )
 
   return <CollageStoreContext.Provider value={value}>{children}</CollageStoreContext.Provider>

--- a/src/collage-studio/state/collageStore.tsx
+++ b/src/collage-studio/state/collageStore.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useReducer, useState, type ReactNode } from 'react'
-import type { CollageDoc } from '../model/collageTypes'
+import { normalizeDoc, type CollageDoc } from '../model/collageTypes'
 import { loadSession, saveSession } from './idb'
 
 const HISTORY_LIMIT = 50
@@ -48,13 +48,17 @@ function reducer(state: State, action: Action): State {
         order: [...state.order, action.doc.id],
         activeId: action.doc.id,
       }
-    case 'OPEN_DOC':
+    case 'OPEN_DOC': {
       // Freshly loaded from a file on disk -- matches what's on disk, so it's clean.
+      // normalizeDoc backfills any fields added after this file might have been
+      // exported (e.g. an older .collage.json missing insertShadowDefault).
+      const doc = normalizeDoc(action.doc)
       return {
-        entries: { ...state.entries, [action.doc.id]: newEntry(action.doc, false) },
-        order: [...state.order, action.doc.id],
-        activeId: action.doc.id,
+        entries: { ...state.entries, [doc.id]: newEntry(doc, false) },
+        order: [...state.order, doc.id],
+        activeId: doc.id,
       }
+    }
     case 'CLOSE_DOC': {
       if (!state.entries[action.id]) return state
       const { [action.id]: _removed, ...entries } = state.entries
@@ -194,7 +198,7 @@ export function CollageStoreProvider({ children }: { children: ReactNode }) {
         const entries: Record<string, DocEntry> = {}
         for (const id of session.order) {
           const stored = session.docs[id]
-          if (stored) entries[id] = newEntry(stored.doc as CollageDoc, stored.dirty)
+          if (stored) entries[id] = newEntry(normalizeDoc(stored.doc as CollageDoc), stored.dirty)
         }
         dispatch({ type: 'HYDRATE', order: session.order, activeId: session.activeId, entries })
       })

--- a/src/collage-studio/state/idb.ts
+++ b/src/collage-studio/state/idb.ts
@@ -31,6 +31,10 @@ export interface StoredImage {
   key: string
   name: string
   blob: Blob
+  // IndexedDB's getAll() returns records ordered by the primary key (the
+  // content hash, i.e. effectively random) -- this is what lets the gallery
+  // sort by when each image was actually added instead.
+  addedAt: number
 }
 
 export async function loadAllImages(): Promise<StoredImage[]> {

--- a/src/collage-studio/state/idb.ts
+++ b/src/collage-studio/state/idb.ts
@@ -63,16 +63,6 @@ export async function deleteImage(key: string): Promise<void> {
   })
 }
 
-export async function clearImages(): Promise<void> {
-  const db = await openDb()
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(IMAGES_STORE, 'readwrite')
-    tx.objectStore(IMAGES_STORE).clear()
-    tx.oncomplete = () => resolve()
-    tx.onerror = () => reject(tx.error)
-  })
-}
-
 export interface StoredSession {
   id: 'main'
   order: string[]

--- a/src/collage-studio/state/imagePoolStore.tsx
+++ b/src/collage-studio/state/imagePoolStore.tsx
@@ -11,6 +11,7 @@ export interface PooledImage {
   file: File
   objectUrl: string
   name: string
+  addedAt: number
 }
 
 interface ImagePoolApi {
@@ -69,7 +70,7 @@ export function ImagePoolProvider({ children }: { children: ReactNode }) {
           for (const img of stored) {
             if (next.has(img.key)) continue
             const file = new File([img.blob], img.name, { type: img.blob.type })
-            next.set(img.key, { key: img.key, file, objectUrl: URL.createObjectURL(img.blob), name: img.name })
+            next.set(img.key, { key: img.key, file, objectUrl: URL.createObjectURL(img.blob), name: img.name, addedAt: img.addedAt ?? 0 })
           }
           return next
         })
@@ -91,21 +92,22 @@ export function ImagePoolProvider({ children }: { children: ReactNode }) {
     const fingerprints = await Promise.all(imageFiles.map(fingerprint))
 
     const keys: string[] = []
-    const newlyAdded: { key: string; file: File }[] = []
+    const newlyAdded: { key: string; file: File; addedAt: number }[] = []
     setPool((prev) => {
       const next = new Map(prev)
       imageFiles.forEach((file, i) => {
         const key = fingerprints[i]
         keys.push(key)
         if (next.has(key)) return
-        next.set(key, { key, file, objectUrl: URL.createObjectURL(file), name: file.name })
-        newlyAdded.push({ key, file })
+        const addedAt = Date.now()
+        next.set(key, { key, file, objectUrl: URL.createObjectURL(file), name: file.name, addedAt })
+        newlyAdded.push({ key, file, addedAt })
       })
       return next
     })
     // Persist new entries only -- fire-and-forget, the in-memory pool is the source of truth for this tab.
-    for (const { key, file } of newlyAdded) {
-      saveImage({ key, name: file.name, blob: file }).catch((e) => console.error('Failed to persist image:', e))
+    for (const { key, file, addedAt } of newlyAdded) {
+      saveImage({ key, name: file.name, blob: file, addedAt }).catch((e) => console.error('Failed to persist image:', e))
     }
     return keys
   }, [])
@@ -142,7 +144,7 @@ export function ImagePoolProvider({ children }: { children: ReactNode }) {
   const get = useCallback((key: string) => pool.get(key), [pool])
 
   const value = useMemo<ImagePoolApi>(
-    () => ({ images: Array.from(pool.values()), get, add, remove, removeMany }),
+    () => ({ images: Array.from(pool.values()).sort((a, b) => b.addedAt - a.addedAt), get, add, remove, removeMany }),
     [pool, get, add, remove, removeMany],
   )
 

--- a/src/collage-studio/state/imagePoolStore.tsx
+++ b/src/collage-studio/state/imagePoolStore.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { clearImages, deleteImage, loadAllImages, saveImage } from './idb'
+import { deleteImage, loadAllImages, saveImage } from './idb'
 
 // Image pool, persisted locally (IndexedDB) so the gallery survives a
 // browser restart -- but never leaves this device and never touches a
@@ -19,8 +19,8 @@ interface ImagePoolApi {
   /** Adds files to the pool, deduping by content fingerprint; returns the resulting keys (added or already-present). */
   add: (files: FileList | File[]) => Promise<string[]>
   remove: (key: string) => void
-  /** Wipes the entire persistent gallery. Any collage still referencing a removed image will show "missing image" until re-added. */
-  clearAll: () => Promise<void>
+  /** Removes several images at once (e.g. "Clear gallery" removing everything unused). */
+  removeMany: (keys: string[]) => Promise<void>
 }
 
 const ImagePoolContext = createContext<ImagePoolApi | null>(null)
@@ -122,17 +122,28 @@ export function ImagePoolProvider({ children }: { children: ReactNode }) {
     deleteImage(key).catch((e) => console.error('Failed to delete persisted image:', e))
   }, [])
 
-  const clearAll = useCallback(async () => {
-    for (const img of poolRef.current.values()) URL.revokeObjectURL(img.objectUrl)
-    setPool(new Map())
-    await clearImages()
+  const removeMany = useCallback(async (keys: string[]) => {
+    if (keys.length === 0) return
+    const keySet = new Set(keys)
+    setPool((prev) => {
+      const next = new Map(prev)
+      for (const key of keySet) {
+        const entry = next.get(key)
+        if (entry) {
+          URL.revokeObjectURL(entry.objectUrl)
+          next.delete(key)
+        }
+      }
+      return next
+    })
+    await Promise.all(keys.map((key) => deleteImage(key).catch((e) => console.error('Failed to delete persisted image:', e))))
   }, [])
 
   const get = useCallback((key: string) => pool.get(key), [pool])
 
   const value = useMemo<ImagePoolApi>(
-    () => ({ images: Array.from(pool.values()), get, add, remove, clearAll }),
-    [pool, get, add, remove, clearAll],
+    () => ({ images: Array.from(pool.values()), get, add, remove, removeMany }),
+    [pool, get, add, remove, removeMany],
   )
 
   return <ImagePoolContext.Provider value={value}>{children}</ImagePoolContext.Provider>


### PR DESCRIPTION
## Summary

Implements the new Claude Design mockup for Collage Studio, plus a round of follow-up fixes from live testing against it. Builds on top of the still-open #70 (shadow defaults, gallery fixes, dialog rendering bug) -- merging this will bring those commits in too.

**From the design mockup:**
- "New ▾" split-button dropdown (starting layouts) replacing the old always-visible template row
- Library panel: add button, Name/Date sort, larger thumbnails with visible filenames
- Resizable library/inspector panels
- Frame toolbar gains a "Clear image" button
- Dark-themed scrollbars
- Mobile Library/Inspector toggles moved into the tabs-bar as icon buttons

**Insert interaction (iterated live after trying the design's simplified version):**
- Started by matching the mockup exactly (seam-toggle only, Inspector reduced to corner-radius)
- Feedback: couldn't move inserts anymore, dragging panned the image instead -- rebuilt with a clear split: drag body = pan image, dedicated move handle = reposition, resize handle = resize, scroll = zoom, double-click = reset to fit
- Insert creation simplified further to a single "+" button (top-left of canvas) instead of a marker per seam
- Remove (X) only shows for the selected insert

**Mobile:**
- Library/inspector no longer overlay the canvas -- share space instead, mutually exclusive (library+canvas, canvas alone, or canvas+inspector, never overlapping)
- "Drop image here" text hidden on narrow layouts (dashed box stays)

**Other fixes from testing:**
- Zoom cap raised from ~3.3x to 50x (frontend + backend kept in sync, verified with a live render smoke test)
- Library thumbnails: resizable via Ctrl+Scroll or pinch (stepped columns-per-row), reverts to auto-fill when the panel itself is resized
- Scrollbar/content overlap fixed (scrollbar-gutter: stable)
- Dedicated "Drop here" dropzone removed -- whole library panel is a drop target now
- Click outside the collage stage deselects the current frame/insert

## Test plan
- [x] `npx tsc --noEmit` clean throughout
- [x] `pnpm build` clean throughout
- [x] Live `/api/export` smoke test against the backend at zoom=45 (near the new cap) -- valid JPEG returned
- [x] Dev server restarted cleanly, `/collage-studio` route verified after each round of changes
- [ ] Manual verification of drag/pinch/touch gestures (can't be exercised via curl/build alone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)