### PR TITLE
Collage Studio: insert aspect ratio + mobile touch fixes

### DIFF
--- a/docs/collage-studio.md
+++ b/docs/collage-studio.md
@@ -152,7 +152,12 @@ Insert
   id, imageKey             # independent from any frame -- not auto-linked to the frame it was created near
   seam: {frameIdA, frameIdB} | null    # starting position only; overridden once dragged (position wins)
   position: {cxPct, cyPct} | null      # set on drag; freely movable/resizable on the canvas, not just seam midpoints
-  sizePct, focal, zoom, featherPx, cornerRadiusPct
+  sizePct, aspectRatio, focal, zoom, featherPx, cornerRadiusPct
+    # aspectRatio is width/height (1 = square, the only shape this used to
+    # support); sizePct still controls overall scale, split between width/
+    # height via sqrt(aspectRatio) so area stays roughly constant as the
+    # shape changes -- see CanvasEditor.tsx's insertRects and
+    # render_engine.py's paste_insert (kept in sync)
   border: {enabled, width, color} | null                                      # null = inherit insertBorderDefault
   shadow: {enabled, offsetPx, angleDeg, blurPx, opacity, color} | null        # null = inherit insertShadowDefault
 ```

--- a/docs/collage-studio.md
+++ b/docs/collage-studio.md
@@ -157,7 +157,7 @@ Insert
     # support); sizePct still controls overall scale, split between width/
     # height via sqrt(aspectRatio) so area stays roughly constant as the
     # shape changes -- see CanvasEditor.tsx's insertRects and
-    # render_engine.py's paste_insert (kept in sync)
+    # canvasExport.ts's renderCollageToBlob (kept in sync, same formula)
   border: {enabled, width, color} | null                                      # null = inherit insertBorderDefault
   shadow: {enabled, offsetPx, angleDeg, blurPx, opacity, color} | null        # null = inherit insertShadowDefault
 ```

--- a/src/collage-studio/collage-studio.css
+++ b/src/collage-studio/collage-studio.css
@@ -563,7 +563,9 @@
 }
 .collage-studio-page .field-row {
   display: flex;
-  gap: 10px;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
 }
 .collage-studio-page .field.checkbox {
   flex-direction: row;

--- a/src/collage-studio/collage-studio.css
+++ b/src/collage-studio/collage-studio.css
@@ -300,6 +300,9 @@
   cursor: col-resize;
   background: transparent;
   flex-shrink: 0;
+  /* Without this, a touch-drag here gets claimed by the browser as a page
+     scroll/pan gesture instead of reaching our pointer handlers. */
+  touch-action: none;
 }
 .collage-studio-page .resize-handle:hover {
   background: #3b82f6;
@@ -437,6 +440,7 @@
   position: absolute;
   z-index: 5;
   background: transparent;
+  touch-action: none;
 }
 .collage-studio-page .divider-horizontal {
   cursor: col-resize;
@@ -513,6 +517,7 @@
   cursor: grab;
   z-index: 6;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+  touch-action: none;
 }
 .collage-studio-page .insert-resize-handle {
   position: absolute;
@@ -524,6 +529,7 @@
   cursor: nwse-resize;
   z-index: 6;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+  touch-action: none;
 }
 
 /* ---- inspector ---- */
@@ -634,7 +640,23 @@
     display: inline-flex;
   }
   .collage-studio-page .resize-handle {
-    display: none;
+    /* Kept visible (was display:none) -- widened for a finger instead of a
+       mouse pointer. Visually still reads as a thin line since the color
+       only shows via :hover/:active, but the actual hit target is bigger. */
+    width: 18px;
+    margin: 0 -6px;
+  }
+  /* Expand the touch target well beyond the visual dot/square (14px) via a
+     pseudo-element instead of resizing the handle itself -- the handle's
+     on-screen position is computed in CanvasEditor.tsx assuming a 14px box,
+     so growing the real element would throw that off-center. A pseudo-
+     element isn't part of the DOM, so pointer events on it still land on
+     (and are handled by) the real parent element. */
+  .collage-studio-page .insert-move-handle::after,
+  .collage-studio-page .insert-resize-handle::after {
+    content: '';
+    position: absolute;
+    inset: -12px;
   }
   .collage-studio-page .library-panel-wrap,
   .collage-studio-page .inspector-panel-wrap {

--- a/src/collage-studio/components/CanvasEditor.tsx
+++ b/src/collage-studio/components/CanvasEditor.tsx
@@ -108,7 +108,14 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
     const out: Record<string, Rect> = {}
     for (const insert of doc.inserts) {
       const sizePct = liveInsertSize && liveInsertSize.insertId === insert.id ? liveInsertSize.sizePct : insert.sizePct
-      const size = sizePct * Math.min(layout.canvasCssW, layout.canvasCssH)
+      const base = sizePct * Math.min(layout.canvasCssW, layout.canvasCssH)
+      // aspectRatio is width/height -- split the resize handle's overall
+      // "size" scale between width and height via sqrt so the two stay
+      // inverse of each other (area roughly constant as aspect changes) and
+      // aspectRatio 1 reduces to exactly the old square behavior (w = h = base).
+      const aspect = Math.max(0.05, Math.min(20, insert.aspectRatio))
+      const w = base * Math.sqrt(aspect)
+      const h = base / Math.sqrt(aspect)
       let cx: number
       let cy: number
       // Seam-anchored by default (created via the seam "+"), but the move
@@ -128,7 +135,7 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
       } else {
         continue
       }
-      out[insert.id] = { x: cx - size / 2, y: cy - size / 2, w: size, h: size }
+      out[insert.id] = { x: cx - w / 2, y: cy - h / 2, w, h }
     }
     return out
   }, [doc, layout, liveInsertPos, liveInsertSize])
@@ -645,6 +652,7 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
                 seam: null,
                 position: { cxPct: 0.5, cyPct: 0.5 },
                 sizePct: 0.26,
+                aspectRatio: 1,
                 focal: { x: 0.5, y: 0.5 },
                 zoom: 1.6,
                 featherPx: 18,

--- a/src/collage-studio/components/CanvasEditor.tsx
+++ b/src/collage-studio/components/CanvasEditor.tsx
@@ -17,7 +17,7 @@ type DragState =
   | { type: 'divider'; pointerId: number; splitId: string; orientation: 'horizontal' | 'vertical'; parentRect: Rect }
   | { type: 'insert-pan'; insertId: string; pointerId: number; startX: number; startY: number; startFocal: FocalPoint; rect: Rect; img: HTMLImageElement; cropW: number; cropH: number }
   | { type: 'insert-move'; insertId: string; pointerId: number; startX: number; startY: number; startCxPct: number; startCyPct: number }
-  | { type: 'insert-resize'; insertId: string; pointerId: number; startX: number; startY: number; startSizePct: number }
+  | { type: 'insert-resize'; insertId: string; pointerId: number; startX: number; startY: number; startW: number; startH: number }
 
 function hitTest(point: { x: number; y: number }, rects: Record<string, Rect>): string | null {
   for (const [id, r] of Object.entries(rects)) {
@@ -67,7 +67,7 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
   const [liveRatio, setLiveRatio] = useState<{ splitId: string; ratio: number } | null>(null)
   const [liveInsertFocal, setLiveInsertFocal] = useState<{ insertId: string; focal: FocalPoint } | null>(null)
   const [liveInsertPos, setLiveInsertPos] = useState<{ insertId: string; cxPct: number; cyPct: number } | null>(null)
-  const [liveInsertSize, setLiveInsertSize] = useState<{ insertId: string; sizePct: number } | null>(null)
+  const [liveInsertSize, setLiveInsertSize] = useState<{ insertId: string; w: number; h: number } | null>(null)
   const forceRedraw = useCallback(() => setTick((t) => t + 1), [])
 
   useEffect(() => {
@@ -107,15 +107,24 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
     if (!doc || !layout) return {}
     const out: Record<string, Rect> = {}
     for (const insert of doc.inserts) {
-      const sizePct = liveInsertSize && liveInsertSize.insertId === insert.id ? liveInsertSize.sizePct : insert.sizePct
-      const base = sizePct * Math.min(layout.canvasCssW, layout.canvasCssH)
-      // aspectRatio is width/height -- split the resize handle's overall
-      // "size" scale between width and height via sqrt so the two stay
-      // inverse of each other (area roughly constant as aspect changes) and
-      // aspectRatio 1 reduces to exactly the old square behavior (w = h = base).
-      const aspect = Math.max(0.05, Math.min(20, insert.aspectRatio))
-      const w = base * Math.sqrt(aspect)
-      const h = base / Math.sqrt(aspect)
+      let w: number
+      let h: number
+      if (liveInsertSize && liveInsertSize.insertId === insert.id) {
+        // Live-resizing: track the drag's raw pixel dimensions directly
+        // rather than round-tripping through sizePct/aspectRatio, so the
+        // bottom-right handle tracks the pointer exactly.
+        w = liveInsertSize.w
+        h = liveInsertSize.h
+      } else {
+        const base = insert.sizePct * Math.min(layout.canvasCssW, layout.canvasCssH)
+        // aspectRatio is width/height -- split the overall "size" scale
+        // between width and height via sqrt so the two stay inverse of each
+        // other (area roughly constant as aspect changes) and aspectRatio 1
+        // reduces to exactly the old square behavior (w = h = base).
+        const aspect = Math.max(0.05, Math.min(20, insert.aspectRatio))
+        w = base * Math.sqrt(aspect)
+        h = base / Math.sqrt(aspect)
+      }
       let cx: number
       let cy: number
       // Seam-anchored by default (created via the seam "+"), but the move
@@ -549,7 +558,10 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
   )
 
   // ---- insert resize handle (DOM overlay, bottom-right anchor) ----
-  const beginInsertResize = useCallback((e: React.PointerEvent<HTMLDivElement>, insertId: string, startSizePct: number) => {
+  // Dragging tracks width and height independently -- unlike the old
+  // uniform-scale resize, this lets the aspect ratio change freely just by
+  // dragging, not only via the Inspector's slider.
+  const beginInsertResize = useCallback((e: React.PointerEvent<HTMLDivElement>, insertId: string, startRect: Rect) => {
     e.stopPropagation()
     const canvasBox = canvasRef.current?.getBoundingClientRect()
     if (!canvasBox) return
@@ -559,7 +571,8 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
       pointerId: e.pointerId,
       startX: e.clientX - canvasBox.left,
       startY: e.clientY - canvasBox.top,
-      startSizePct,
+      startW: startRect.w,
+      startH: startRect.h,
     }
     e.currentTarget.setPointerCapture(e.pointerId)
   }, [])
@@ -567,29 +580,35 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
   const onInsertResizePointerMove = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       const drag = dragRef.current
-      if (!drag || drag.type !== 'insert-resize' || !layout || !canvasRef.current) return
+      if (!drag || drag.type !== 'insert-resize' || !canvasRef.current) return
       const canvasBox = canvasRef.current.getBoundingClientRect()
       const x = e.clientX - canvasBox.left
       const y = e.clientY - canvasBox.top
-      const delta = ((x - drag.startX) + (y - drag.startY)) / 2
-      const newSizePct = Math.max(0.05, Math.min(0.6, drag.startSizePct + delta / Math.min(layout.canvasCssW, layout.canvasCssH)))
-      setLiveInsertSize({ insertId: drag.insertId, sizePct: newSizePct })
+      const MIN_PX = 20
+      const w = Math.max(MIN_PX, drag.startW + (x - drag.startX))
+      const h = Math.max(MIN_PX, drag.startH + (y - drag.startY))
+      setLiveInsertSize({ insertId: drag.insertId, w, h })
     },
-    [layout],
+    [],
   )
 
   const onInsertResizePointerUp = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       const drag = dragRef.current
-      if (!drag || drag.type !== 'insert-resize') return
+      if (!drag || drag.type !== 'insert-resize' || !layout) return
       dragRef.current = null
       e.currentTarget.releasePointerCapture(e.pointerId)
       setLiveInsertSize((live) => {
-        if (live) editDoc((d) => ({ ...d, inserts: d.inserts.map((i) => (i.id === live.insertId ? { ...i, sizePct: live.sizePct } : i)) }))
+        if (live) {
+          const minDim = Math.min(layout.canvasCssW, layout.canvasCssH)
+          const sizePct = Math.max(0.05, Math.min(0.6, Math.sqrt(live.w * live.h) / minDim))
+          const aspectRatio = Math.max(0.05, Math.min(20, live.w / live.h))
+          editDoc((d) => ({ ...d, inserts: d.inserts.map((i) => (i.id === live.insertId ? { ...i, sizePct, aspectRatio } : i)) }))
+        }
         return null
       })
     },
-    [editDoc],
+    [editDoc, layout],
   )
 
   if (!doc || !layout) {
@@ -686,9 +705,7 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
                 left: insertRects[selectedInsertId].x + insertRects[selectedInsertId].w - 6,
                 top: insertRects[selectedInsertId].y + insertRects[selectedInsertId].h - 6,
               }}
-              onPointerDown={(e) =>
-                beginInsertResize(e, selectedInsertId, doc.inserts.find((i) => i.id === selectedInsertId)?.sizePct ?? 0.26)
-              }
+              onPointerDown={(e) => beginInsertResize(e, selectedInsertId, insertRects[selectedInsertId])}
               onPointerMove={onInsertResizePointerMove}
               onPointerUp={onInsertResizePointerUp}
               title="Drag to resize"

--- a/src/collage-studio/components/CanvasEditor.tsx
+++ b/src/collage-studio/components/CanvasEditor.tsx
@@ -229,6 +229,10 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
   // ---- pointer interaction on the canvas itself (select / pan / move insert) ----
   const onCanvasPointerDown = useCallback(
     (e: React.PointerEvent<HTMLCanvasElement>) => {
+      // A second (or third...) touch starting a pinch shouldn't hijack the
+      // single-pointer pan/move drag the first touch may have already
+      // started -- isPrimary is only true for the first active touch point.
+      if (!e.isPrimary) return
       if (!doc || !layout) return
       const box = e.currentTarget.getBoundingClientRect()
       const point = { x: e.clientX - box.left, y: e.clientY - box.top }
@@ -412,6 +416,71 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
     }
     canvas.addEventListener('wheel', handler, { passive: false })
     return () => canvas.removeEventListener('wheel', handler)
+  }, [doc, layout, insertRects, editDoc])
+
+  // Two-finger pinch zooms whichever frame/insert is under the pinch's
+  // midpoint -- the touch equivalent of the wheel handler above. Kept in a
+  // ref (not a plain closure variable) so the active gesture survives this
+  // effect re-running mid-pinch, which it does on every editDoc call since
+  // `doc` is a dependency (same as the wheel handler already relies on).
+  const pinchRef = useRef<{ kind: 'insert' | 'frame'; id: string; lastDist: number } | null>(null)
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas || !doc || !layout) return
+    const touchDist = (t: TouchList) => Math.hypot(t[0].clientX - t[1].clientX, t[0].clientY - t[1].clientY)
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (e.touches.length !== 2) return
+      const box = canvas.getBoundingClientRect()
+      const point = {
+        x: (e.touches[0].clientX + e.touches[1].clientX) / 2 - box.left,
+        y: (e.touches[0].clientY + e.touches[1].clientY) / 2 - box.top,
+      }
+      const insertId = hitTest(point, insertRects)
+      if (insertId && doc.inserts.find((i) => i.id === insertId)?.imageKey) {
+        pinchRef.current = { kind: 'insert', id: insertId, lastDist: touchDist(e.touches) }
+        return
+      }
+      const frameId = hitTest(point, layout.frameRects)
+      if (frameId && layout.frames[frameId]?.image) {
+        pinchRef.current = { kind: 'frame', id: frameId, lastDist: touchDist(e.touches) }
+      }
+    }
+
+    const onTouchMove = (e: TouchEvent) => {
+      const pinch = pinchRef.current
+      if (e.touches.length !== 2 || !pinch) return
+      e.preventDefault()
+      const newDist = touchDist(e.touches)
+      const ratio = newDist / pinch.lastDist
+      pinch.lastDist = newDist
+      if (pinch.kind === 'insert') {
+        const insert = doc.inserts.find((i) => i.id === pinch.id)
+        if (!insert) return
+        const nextZoom = Math.max(1, Math.min(MAX_ZOOM, insert.zoom * ratio))
+        editDoc((d) => ({ ...d, inserts: d.inserts.map((i) => (i.id === pinch.id ? { ...i, zoom: nextZoom } : i)) }))
+      } else {
+        const frame = layout.frames[pinch.id]
+        if (!frame?.image) return
+        const nextZoom = Math.max(1, Math.min(MAX_ZOOM, frame.image.zoom * ratio))
+        editDoc((d) => ({ ...d, tree: updateFrame(d.tree, pinch.id, (f) => (f.image ? { ...f, image: { ...f.image, zoom: nextZoom } } : f)) }))
+      }
+    }
+
+    const onTouchEnd = (e: TouchEvent) => {
+      if (e.touches.length < 2) pinchRef.current = null
+    }
+
+    canvas.addEventListener('touchstart', onTouchStart, { passive: true })
+    canvas.addEventListener('touchmove', onTouchMove, { passive: false })
+    canvas.addEventListener('touchend', onTouchEnd)
+    canvas.addEventListener('touchcancel', onTouchEnd)
+    return () => {
+      canvas.removeEventListener('touchstart', onTouchStart)
+      canvas.removeEventListener('touchmove', onTouchMove)
+      canvas.removeEventListener('touchend', onTouchEnd)
+      canvas.removeEventListener('touchcancel', onTouchEnd)
+    }
   }, [doc, layout, insertRects, editDoc])
 
   const assignImageToDropTarget = useCallback(
@@ -601,7 +670,10 @@ export function CanvasEditor({ previewMode }: CanvasEditorProps) {
       setLiveInsertSize((live) => {
         if (live) {
           const minDim = Math.min(layout.canvasCssW, layout.canvasCssH)
-          const sizePct = Math.max(0.05, Math.min(0.6, Math.sqrt(live.w * live.h) / minDim))
+          // No practical upper limit on insert size (it can be bigger than
+          // the canvas itself) -- only a small floor to avoid a degenerate
+          // near-zero box.
+          const sizePct = Math.max(0.02, Math.sqrt(live.w * live.h) / minDim)
           const aspectRatio = Math.max(0.05, Math.min(20, live.w / live.h))
           editDoc((d) => ({ ...d, inserts: d.inserts.map((i) => (i.id === live.insertId ? { ...i, sizePct, aspectRatio } : i)) }))
         }

--- a/src/collage-studio/components/InspectorPanel.tsx
+++ b/src/collage-studio/components/InspectorPanel.tsx
@@ -8,19 +8,6 @@ const ASPECT_PRESETS: { label: string; ratio: number }[] = [
   { label: '4:5', ratio: 5 / 4 },
 ]
 
-// Insert.aspectRatio is width/height (unlike ASPECT_PRESETS above, which is
-// height/width for the canvas's own width->height derivation) -- so these
-// labels read directly as the ratio value, no inversion needed.
-const INSERT_ASPECT_PRESETS: { label: string; ratio: number }[] = [
-  { label: '1:1', ratio: 1 },
-  { label: '4:5', ratio: 4 / 5 },
-  { label: '5:4', ratio: 5 / 4 },
-  { label: '2:3', ratio: 2 / 3 },
-  { label: '3:2', ratio: 3 / 2 },
-  { label: '9:16', ratio: 9 / 16 },
-  { label: '16:9', ratio: 16 / 9 },
-]
-
 function NumberField({
   label,
   value,
@@ -297,21 +284,9 @@ export function InspectorPanel() {
               here -- they follow the doc-level defaults (see the "Inserts
               (default border/shadow)" sections above). */}
           <p className="hint">
-            Drag the insert to pan its image, scroll to zoom, or use the move/resize handles. Double-click to reset
-            zoom/pan.
+            Drag the insert to pan its image, scroll to zoom, or use the move/resize handles (bottom-right also
+            changes aspect ratio freely). Double-click to reset zoom/pan.
           </p>
-          <div className="field-row">
-            <span className="hint">Aspect:</span>
-            {INSERT_ASPECT_PRESETS.map((preset) => (
-              <button
-                key={preset.label}
-                className={Math.abs(selectedInsert.aspectRatio - preset.ratio) < 0.001 ? 'active' : undefined}
-                onClick={() => updateInsert(selectedInsert.id, { aspectRatio: preset.ratio })}
-              >
-                {preset.label}
-              </button>
-            ))}
-          </div>
           <NumberField
             label="Aspect ratio (width : height)"
             min={0.2}

--- a/src/collage-studio/components/InspectorPanel.tsx
+++ b/src/collage-studio/components/InspectorPanel.tsx
@@ -8,6 +8,19 @@ const ASPECT_PRESETS: { label: string; ratio: number }[] = [
   { label: '4:5', ratio: 5 / 4 },
 ]
 
+// Insert.aspectRatio is width/height (unlike ASPECT_PRESETS above, which is
+// height/width for the canvas's own width->height derivation) -- so these
+// labels read directly as the ratio value, no inversion needed.
+const INSERT_ASPECT_PRESETS: { label: string; ratio: number }[] = [
+  { label: '1:1', ratio: 1 },
+  { label: '4:5', ratio: 4 / 5 },
+  { label: '5:4', ratio: 5 / 4 },
+  { label: '2:3', ratio: 2 / 3 },
+  { label: '3:2', ratio: 3 / 2 },
+  { label: '9:16', ratio: 9 / 16 },
+  { label: '16:9', ratio: 16 / 9 },
+]
+
 function NumberField({
   label,
   value,
@@ -287,6 +300,26 @@ export function InspectorPanel() {
             Drag the insert to pan its image, scroll to zoom, or use the move/resize handles. Double-click to reset
             zoom/pan.
           </p>
+          <div className="field-row">
+            <span className="hint">Aspect:</span>
+            {INSERT_ASPECT_PRESETS.map((preset) => (
+              <button
+                key={preset.label}
+                className={Math.abs(selectedInsert.aspectRatio - preset.ratio) < 0.001 ? 'active' : undefined}
+                onClick={() => updateInsert(selectedInsert.id, { aspectRatio: preset.ratio })}
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+          <NumberField
+            label="Aspect ratio (width : height)"
+            min={0.2}
+            max={5}
+            step={0.05}
+            value={selectedInsert.aspectRatio}
+            onChange={(v) => updateInsert(selectedInsert.id, { aspectRatio: v })}
+          />
           <label className="field">
             <span>Corner radius (0 = square, 50 = circle)</span>
             <input

--- a/src/collage-studio/model/canvasExport.ts
+++ b/src/collage-studio/model/canvasExport.ts
@@ -76,7 +76,15 @@ export async function renderCollageToBlob(doc: CollageDoc, imageUrls: Map<string
       const img = images.get(insert.imageKey)
       if (!img) continue
 
-      const size = insert.sizePct * Math.min(canvasW, canvasH)
+      const base = insert.sizePct * Math.min(canvasW, canvasH)
+      // aspectRatio is width/height -- split the overall "size" scale
+      // between width and height via sqrt so the two stay inverse of each
+      // other (area roughly constant as aspect changes) and aspectRatio 1
+      // reduces to exactly the old square behavior (w = h = base). Mirrors
+      // CanvasEditor.tsx's insertRects computation.
+      const aspect = Math.max(0.05, Math.min(20, insert.aspectRatio))
+      const w = base * Math.sqrt(aspect)
+      const h = base / Math.sqrt(aspect)
       let cx: number
       let cy: number
       if (insert.position) {
@@ -90,7 +98,7 @@ export async function renderCollageToBlob(doc: CollageDoc, imageUrls: Map<string
       } else {
         continue
       }
-      const rect: Rect = { x: cx - size / 2, y: cy - size / 2, w: size, h: size }
+      const rect: Rect = { x: cx - w / 2, y: cy - h / 2, w, h }
 
       const shadow = insert.shadow ?? doc.insertShadowDefault
       if (shadow.enabled) drawInsertShadow(ctx, rect, insert.cornerRadiusPct, shadow, 1)

--- a/src/collage-studio/model/canvasRender.ts
+++ b/src/collage-studio/model/canvasRender.ts
@@ -85,7 +85,7 @@ export interface InsertShadowSpec {
 
 /** Blurred, colored silhouette of the insert's rounded shape, offset by
  * angle/distance -- drawn *before* the insert image itself so it sits behind it.
- * Mirrors render_engine.py's make_insert_shadow (same angle convention: 0=right, 90=down). */
+ * (Angle convention: 0=right, 90=down.) */
 export function drawInsertShadow(ctx: CanvasRenderingContext2D, destRect: Rect, cornerRadiusPct: number, shadow: InsertShadowSpec, scale: number) {
   if (shadow.opacity <= 0) return
   const w = Math.round(destRect.w)

--- a/src/collage-studio/model/collageTypes.ts
+++ b/src/collage-studio/model/collageTypes.ts
@@ -81,6 +81,10 @@ export interface Insert {
   seam: SeamRef | null
   position: PositionPct | null
   sizePct: number
+  // width / height. 1 = square (the only shape this used to support).
+  // sizePct still controls overall scale; this only controls the shape --
+  // see the aspect-preserving w/h split in CanvasEditor.tsx's insertRects.
+  aspectRatio: number
   focal: FocalPoint
   zoom: number
   featherPx: number
@@ -139,6 +143,7 @@ export function normalizeDoc(doc: CollageDoc): CollageDoc {
     ...doc,
     insertBorderDefault: doc.insertBorderDefault ?? { ...DEFAULT_INSERT_BORDER },
     insertShadowDefault: doc.insertShadowDefault ?? { ...DEFAULT_INSERT_SHADOW },
+    inserts: doc.inserts.map((i) => ({ ...i, aspectRatio: i.aspectRatio ?? 1 })),
   }
 }
 


### PR DESCRIPTION
## Summary

Rebased onto latest main (which in the meantime moved Render to a fully client-side `<canvas>` export, no backend at all).

**Insert aspect ratio:**
- Inserts can be any aspect ratio now, not just 1x1 square (`Insert.aspectRatio`, width/height, defaults to 1 so existing docs render unchanged)
- Dragging the bottom-right resize handle changes width/height independently -- aspect ratio changes freely just by dragging, no preset buttons

**Mobile touch fixes** (from real device testing -- these were flat-out broken with touch, worked fine with a mouse):
- Panel resize handle, frame-split dividers, and insert move/resize handles were all missing `touch-action: none`, so a touch-drag on any of them got claimed by the browser as a page scroll instead of reaching the app -- this alone explained "can't resize panels", "can't resize frames", and "can't move insert" all at once
- Added two-finger pinch-to-zoom on the canvas for whichever frame/insert is under the pinch, mirroring the existing wheel-zoom
- Insert size no longer has a practical upper limit

**Post-rebase reconciliation** (this branch's aspect-ratio work predates canvasExport.ts, so nothing conflicted -- these needed a manual follow-up, not just conflict resolution):
- Ported the aspect-ratio width/height-split formula into `canvasExport.ts` so the final export matches what the live preview shows for non-square inserts (previously would have silently rendered them square)
- Dropped a stale "can't reach 127.0.0.1 backend" error message that auto-merged into `Toolbar.handleRender`'s catch block without a flagged conflict -- obsolete now that Render never calls a backend
- Fixed two leftover comments referencing the deleted `render_engine.py`

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm build` clean
- [x] Dev server restarted cleanly, `/collage-studio` route verified
- [ ] Manual: resize panels/frames, move/resize an insert, and pinch-zoom on an actual touch device (can't be verified via curl/build alone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)